### PR TITLE
Style tables so they appear similar to how they look on Github

### DIFF
--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -5,5 +5,5 @@ layout: default
 
 <p class="post-meta">{{ page.date | date: "%b %-d, %Y" }}{% if page.author %} by {{ page.author }}{% endif %}{% if page.meta %} • {{ page.meta }}{% endif %}</p>
 
-{{ content }}
+<div class="documentation-content">{{ content }}</div>
 

--- a/css/style.css
+++ b/css/style.css
@@ -532,7 +532,19 @@ footer hr {
 	border-top: none;
 }
 
+.documentation-content table tr {
+	background-color: #fff;
+	border-top: 1px solid #c6cbd1;
+}
 
+.documentation-content table th, .documentation-content table td {
+	padding: 6px 13px;
+	border: 1px solid #dfe2e5;
+}
+
+.documentation-content table tr:nth-child(2n) {
+	background-color: #f6f8fa;
+}
 
 
 


### PR DESCRIPTION
I think the table styling we have right now is hard to read. Compare the table at the bottom of https://storm.apache.org/releases/2.0.0-SNAPSHOT/storm-kafka-client.html with how it appears when shown on Github https://github.com/apache/storm-site/blob/asf-site/releases/2.0.0-SNAPSHOT/storm-kafka-client.md. 

I copied a couple of rules from the styling used by GH, and added a container for documentation content, so the style will only apply to tables in page content.