### PR TITLE
Add .asf.yaml file for website publishing

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,2 @@
+publish:
+  whoami: asf-site


### PR DESCRIPTION
According to the email titled "[NOTICE] Git web site publishing to be done via .asf.yaml only as of July 1st" ([link](https://lists.apache.org/thread.html/raf30ca1c77b81bc8c535c53b7aff38e1ff3c755ce84f4a40a6d8ad53%40%3Cprivate.storm.apache.org%3E)):

```

In short, one puts a file called .asf.yaml into the branch that needs to 
be published as the project's web site, with the following two-line 
content, in this case assuming the published branch is 'asf-site':

publish:
   whoami: asf-site
```

Check https://infra-reports.apache.org/site-source/ to know the current status