### PR TITLE
Move company logos from homepage to powered-by page

### DIFF
--- a/Powered-By.md
+++ b/Powered-By.md
@@ -5,6 +5,47 @@ documentation: true
 ---
 Want to be added to this page? Send an email [here](mailto:dev@storm.apache.org).
 
+
+<div class="content">
+  <div class="container-fluid">
+        <div class="row">
+          <div class="col-md-12">
+              <div id="owl-example" class="owl-carousel">
+                    <a href="http://www.yahoo.com/" target="blank"><img src="images/logos/yahoo.png" class="img-responsive"></a>
+                    <a href="http://www.twitter.com/" target="blank"><img src="images/logos/twitter.jpg" class="img-responsive"></a>
+                    <a href="http://www.spotify.com/" target="blank"><img src="images/logos/spotify.jpg" class="img-responsive"></a>
+                    <a href="http://www.yahoo.co.jp/" target="blank"><img src="images/logos/yahoo-japan.jpg" class="img-responsive"></a>
+                    <a href="http://www.yelp.com/" target="blank"><img src="images/logos/yelp.jpg" class="img-responsive"></a>
+                    <a href="http://flipboard.com/" target="blank"><img src="images/logos/flipboard.jpg" class="img-responsive"></a>
+                    <a href="http://www.ooyala.com/" target="blank"><img src="images/logos/ooyala.jpg" class="img-responsive"></a>
+                    <a href="http://groupon.com/" target="blank"><img src="images/logos/groupon.jpg" class="img-responsive"></a>
+                    <a href="http://www.parc.com/" target="blank"><img src="images/logos/parc.png" class="img-responsive"></a>
+                    <a href="http://www.alibaba.com/" target="blank"><img src="images/logos/alibaba.jpg" class="img-responsive"></a>
+                    <a href="http://www.baidu.com/" target="blank"><img src="images/logos/bai.jpg" class="img-responsive"></a>
+                    <a href="http://www.cerner.com/" target="blank"><img src="images/logos/cerner.jpg" class="img-responsive"></a>
+                    <a href="http://www.fullcontact.com/" target="blank"><img src="images/logos/fullcontact.jpg" class="img-responsive"></a>
+                    <a href="http://www.healthmarketscience.com/" target="blank"><img src="images/logos/health-market-science.jpg" class="img-responsive"></a>
+                    <a href="http://www.infochimps.com/" target="blank"><img src="images/logos/infochimp.jpg" class="img-responsive"></a>
+                    <a href="http://www.klout.com/" target="blank"><img src="images/logos/klout.jpg" class="img-responsive"></a>
+                    <a href="http://www.loggly.com/" target="blank"><img src="images/logos/loggly.jpg" class="img-responsive"></a>
+                    <a href="http://www.premise.is/" target="blank"><img src="images/logos/premise.jpg" class="img-responsive"></a>
+                    <a href="http://www.iqyi.com/" target="blank"><img src="images/logos/qiy.jpg" class="img-responsive"></a>
+                    <a href="http://www.quicklizard.com/" target="blank"><img src="images/logos/quicklizard.jpg" class="img-responsive"></a>
+                    <a href="http://www.rocketfuel.com/" target="blank"><img src="images/logos/rocketfuel.jpg" class="img-responsive"></a>
+                    <a href="http://www.rubiconproject.com/" target="blank"><img src="images/logos/rubicon.jpg" class="img-responsive"></a>
+                    <a href="http://spider.io/" target="blank" ><img src="images/logos/spider.jpg" class="img-responsive"></a>
+                    <a href="http://www.taobao.com/" target="blank" ><img src="images/logos/taobao.jpg" class="img-responsive"></a>
+                    <a href="http://www.weather.com/" target="blank" ><img src="images/logos/the-weather-channel.jpg" class="img-responsive"></a>
+                    <a href="https://www.verisigninc.com/" target="blank" ><img src="images/logos/verisign.jpg" class="img-responsive"></a>
+                    <a href="http://www.webmd.com/" target="blank" ><img src="images/logos/webmd.jpg" class="img-responsive"></a>
+                    <a href="http://www.wego.com/"><img src="images/logos/wego.jpg" class="img-responsive"></a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+
 <table class="table table-striped">
 
 <tr>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -48,6 +48,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="{{ site.posts[0].url }}" id="news">News</a></li>

--- a/content/2012/08/02/storm080-released.html
+++ b/content/2012/08/02/storm080-released.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2012/09/06/storm081-released.html
+++ b/content/2012/09/06/storm081-released.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2013/01/11/storm082-released.html
+++ b/content/2013/01/11/storm082-released.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2013/12/08/storm090-released.html
+++ b/content/2013/12/08/storm090-released.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2014/04/10/storm-logo-contest.html
+++ b/content/2014/04/10/storm-logo-contest.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2014/04/17/logo-pforrest.html
+++ b/content/2014/04/17/logo-pforrest.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2014/04/17/logo-squinones.html
+++ b/content/2014/04/17/logo-squinones.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2014/04/19/logo-ssuleman.html
+++ b/content/2014/04/19/logo-ssuleman.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2014/04/21/logo-rmarshall.html
+++ b/content/2014/04/21/logo-rmarshall.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2014/04/22/logo-zsayari.html
+++ b/content/2014/04/22/logo-zsayari.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2014/04/23/logo-abartos.html
+++ b/content/2014/04/23/logo-abartos.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2014/04/27/logo-cboustead.html
+++ b/content/2014/04/27/logo-cboustead.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2014/04/27/logo-sasili.html
+++ b/content/2014/04/27/logo-sasili.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2014/04/29/logo-jlee1.html
+++ b/content/2014/04/29/logo-jlee1.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2014/04/29/logo-jlee2.html
+++ b/content/2014/04/29/logo-jlee2.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2014/04/29/logo-jlee3.html
+++ b/content/2014/04/29/logo-jlee3.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2014/05/27/round1-results.html
+++ b/content/2014/05/27/round1-results.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2014/06/17/contest-results.html
+++ b/content/2014/06/17/contest-results.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2014/06/25/storm092-released.html
+++ b/content/2014/06/25/storm092-released.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2014/10/20/storm093-release-candidate.html
+++ b/content/2014/10/20/storm093-release-candidate.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2014/11/25/storm093-released.html
+++ b/content/2014/11/25/storm093-released.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2015/03/25/storm094-released.html
+++ b/content/2015/03/25/storm094-released.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2015/06/04/storm095-released.html
+++ b/content/2015/06/04/storm095-released.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2015/06/15/storm0100-beta-released.html
+++ b/content/2015/06/15/storm0100-beta-released.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2015/11/05/storm0100-released.html
+++ b/content/2015/11/05/storm0100-released.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2015/11/05/storm096-released.html
+++ b/content/2015/11/05/storm096-released.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2016/04/12/storm100-released.html
+++ b/content/2016/04/12/storm100-released.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2016/05/05/storm0101-released.html
+++ b/content/2016/05/05/storm0101-released.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2016/05/06/storm101-released.html
+++ b/content/2016/05/06/storm101-released.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2016/08/10/storm102-released.html
+++ b/content/2016/08/10/storm102-released.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2016/09/07/storm097-released.html
+++ b/content/2016/09/07/storm097-released.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2016/09/14/storm0102-released.html
+++ b/content/2016/09/14/storm0102-released.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2017/02/14/storm103-released.html
+++ b/content/2017/02/14/storm103-released.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2017/03/29/storm110-released.html
+++ b/content/2017/03/29/storm110-released.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2017/07/28/storm104-released.html
+++ b/content/2017/07/28/storm104-released.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2017/08/01/storm111-released.html
+++ b/content/2017/08/01/storm111-released.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2017/09/15/storm105-released.html
+++ b/content/2017/09/15/storm105-released.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2018/02/14/storm106-released.html
+++ b/content/2018/02/14/storm106-released.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2018/02/15/storm112-released.html
+++ b/content/2018/02/15/storm112-released.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2018/02/15/storm120-released.html
+++ b/content/2018/02/15/storm120-released.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2018/02/19/storm121-released.html
+++ b/content/2018/02/19/storm121-released.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2018/06/04/storm113-released.html
+++ b/content/2018/06/04/storm113-released.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2018/06/04/storm122-released.html
+++ b/content/2018/06/04/storm122-released.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2019/05/30/storm200-released.html
+++ b/content/2019/05/30/storm200-released.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2019/07/18/storm123-released.html
+++ b/content/2019/07/18/storm123-released.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2019/10/31/storm210-released.html
+++ b/content/2019/10/31/storm210-released.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2020/06/30/storm220-released.html
+++ b/content/2020/06/30/storm220-released.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/2021/09/27/storm230-released.html
+++ b/content/2021/09/27/storm230-released.html
@@ -103,6 +103,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/Powered-By.html
+++ b/content/Powered-By.html
@@ -100,6 +100,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>
@@ -119,6 +120,45 @@
 <p class="post-meta"></p>
 
 <div class="documentation-content"><p>Want to be added to this page? Send an email <a href="mailto:dev@storm.apache.org">here</a>.</p>
+
+<div class="content">
+  <div class="container-fluid">
+        <div class="row">
+          <div class="col-md-12">
+              <div id="owl-example" class="owl-carousel">
+                    <a href="http://www.yahoo.com/" target="blank"><img src="images/logos/yahoo.png" class="img-responsive"></a>
+                    <a href="http://www.twitter.com/" target="blank"><img src="images/logos/twitter.jpg" class="img-responsive"></a>
+                    <a href="http://www.spotify.com/" target="blank"><img src="images/logos/spotify.jpg" class="img-responsive"></a>
+                    <a href="http://www.yahoo.co.jp/" target="blank"><img src="images/logos/yahoo-japan.jpg" class="img-responsive"></a>
+                    <a href="http://www.yelp.com/" target="blank"><img src="images/logos/yelp.jpg" class="img-responsive"></a>
+                    <a href="http://flipboard.com/" target="blank"><img src="images/logos/flipboard.jpg" class="img-responsive"></a>
+                    <a href="http://www.ooyala.com/" target="blank"><img src="images/logos/ooyala.jpg" class="img-responsive"></a>
+                    <a href="http://groupon.com/" target="blank"><img src="images/logos/groupon.jpg" class="img-responsive"></a>
+                    <a href="http://www.parc.com/" target="blank"><img src="images/logos/parc.png" class="img-responsive"></a>
+                    <a href="http://www.alibaba.com/" target="blank"><img src="images/logos/alibaba.jpg" class="img-responsive"></a>
+                    <a href="http://www.baidu.com/" target="blank"><img src="images/logos/bai.jpg" class="img-responsive"></a>
+                    <a href="http://www.cerner.com/" target="blank"><img src="images/logos/cerner.jpg" class="img-responsive"></a>
+                    <a href="http://www.fullcontact.com/" target="blank"><img src="images/logos/fullcontact.jpg" class="img-responsive"></a>
+                    <a href="http://www.healthmarketscience.com/" target="blank"><img src="images/logos/health-market-science.jpg" class="img-responsive"></a>
+                    <a href="http://www.infochimps.com/" target="blank"><img src="images/logos/infochimp.jpg" class="img-responsive"></a>
+                    <a href="http://www.klout.com/" target="blank"><img src="images/logos/klout.jpg" class="img-responsive"></a>
+                    <a href="http://www.loggly.com/" target="blank"><img src="images/logos/loggly.jpg" class="img-responsive"></a>
+                    <a href="http://www.premise.is/" target="blank"><img src="images/logos/premise.jpg" class="img-responsive"></a>
+                    <a href="http://www.iqyi.com/" target="blank"><img src="images/logos/qiy.jpg" class="img-responsive"></a>
+                    <a href="http://www.quicklizard.com/" target="blank"><img src="images/logos/quicklizard.jpg" class="img-responsive"></a>
+                    <a href="http://www.rocketfuel.com/" target="blank"><img src="images/logos/rocketfuel.jpg" class="img-responsive"></a>
+                    <a href="http://www.rubiconproject.com/" target="blank"><img src="images/logos/rubicon.jpg" class="img-responsive"></a>
+                    <a href="http://spider.io/" target="blank" ><img src="images/logos/spider.jpg" class="img-responsive"></a>
+                    <a href="http://www.taobao.com/" target="blank" ><img src="images/logos/taobao.jpg" class="img-responsive"></a>
+                    <a href="http://www.weather.com/" target="blank" ><img src="images/logos/the-weather-channel.jpg" class="img-responsive"></a>
+                    <a href="https://www.verisigninc.com/" target="blank" ><img src="images/logos/verisign.jpg" class="img-responsive"></a>
+                    <a href="http://www.webmd.com/" target="blank" ><img src="images/logos/webmd.jpg" class="img-responsive"></a>
+                    <a href="http://www.wego.com/"><img src="images/logos/wego.jpg" class="img-responsive"></a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
 
 <table class="table table-striped">
 

--- a/content/about/deployment.html
+++ b/content/about/deployment.html
@@ -100,6 +100,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/about/fault-tolerant.html
+++ b/content/about/fault-tolerant.html
@@ -100,6 +100,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/about/free-and-open-source.html
+++ b/content/about/free-and-open-source.html
@@ -100,6 +100,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/about/guarantees-data-processing.html
+++ b/content/about/guarantees-data-processing.html
@@ -100,6 +100,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/about/integrates.html
+++ b/content/about/integrates.html
@@ -100,6 +100,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/about/multi-language.html
+++ b/content/about/multi-language.html
@@ -100,6 +100,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/about/scalable.html
+++ b/content/about/scalable.html
@@ -100,6 +100,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/about/simple-api.html
+++ b/content/about/simple-api.html
@@ -100,6 +100,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/contribute/BYLAWS.html
+++ b/content/contribute/BYLAWS.html
@@ -100,6 +100,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/contribute/Contributing-to-Storm.html
+++ b/content/contribute/Contributing-to-Storm.html
@@ -100,6 +100,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/contribute/People.html
+++ b/content/contribute/People.html
@@ -100,6 +100,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/downloads.html
+++ b/content/downloads.html
@@ -100,6 +100,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/feed.xml
+++ b/content/feed.xml
@@ -5,8 +5,8 @@
     <description></description>
     <link>http://storm.apache.org/</link>
     <atom:link href="http://storm.apache.org/feed.xml" rel="self" type="application/rss+xml"/>
-    <pubDate>Mon, 27 Sep 2021 15:11:55 -0500</pubDate>
-    <lastBuildDate>Mon, 27 Sep 2021 15:11:55 -0500</lastBuildDate>
+    <pubDate>Mon, 27 Sep 2021 16:36:29 -0500</pubDate>
+    <lastBuildDate>Mon, 27 Sep 2021 16:36:29 -0500</lastBuildDate>
     <generator>Jekyll v3.6.2</generator>
     
       <item>

--- a/content/getting-help.html
+++ b/content/getting-help.html
@@ -100,6 +100,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/index.html
+++ b/content/index.html
@@ -100,6 +100,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>
@@ -176,45 +177,6 @@
                         var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");
                         isMobile();
                     </script>
-                </div>
-            </div>
-        </div>
-        <div class="row">
-          <div class="col-md-12">
-              <div id="owl-example" class="owl-carousel">
-                    <a href="http://www.yahoo.com/" target="blank"><img src="images/logos/yahoo.png" class="img-responsive"></a>
-                    <a href="http://www.twitter.com/" target="blank"><img src="images/logos/twitter.jpg" class="img-responsive"></a>
-                    <a href="http://www.spotify.com/" target="blank"><img src="images/logos/spotify.jpg" class="img-responsive"></a>
-                    <a href="http://www.yahoo.co.jp/" target="blank"><img src="images/logos/yahoo-japan.jpg" class="img-responsive"></a>
-                    <a href="http://www.yelp.com/" target="blank"><img src="images/logos/yelp.jpg" class="img-responsive"></a>
-                    <a href="http://flipboard.com/" target="blank"><img src="images/logos/flipboard.jpg" class="img-responsive"></a>
-                    <a href="http://www.ooyala.com/" target="blank"><img src="images/logos/ooyala.jpg" class="img-responsive"></a>
-                    <a href="http://groupon.com/" target="blank"><img src="images/logos/groupon.jpg" class="img-responsive"></a>
-                    <a href="http://www.parc.com/" target="blank"><img src="images/logos/parc.png" class="img-responsive"></a>
-                    <a href="http://www.alibaba.com/" target="blank"><img src="images/logos/alibaba.jpg" class="img-responsive"></a>
-                    <a href="http://www.baidu.com/" target="blank"><img src="images/logos/bai.jpg" class="img-responsive"></a>
-                    <a href="http://www.cerner.com/" target="blank"><img src="images/logos/cerner.jpg" class="img-responsive"></a>
-                    <a href="http://www.fullcontact.com/" target="blank"><img src="images/logos/fullcontact.jpg" class="img-responsive"></a>
-                    <a href="http://www.healthmarketscience.com/" target="blank"><img src="images/logos/health-market-science.jpg" class="img-responsive"></a>
-                    <a href="http://www.infochimps.com/" target="blank"><img src="images/logos/infochimp.jpg" class="img-responsive"></a>
-                    <a href="http://www.klout.com/" target="blank"><img src="images/logos/klout.jpg" class="img-responsive"></a>
-                    <a href="http://www.loggly.com/" target="blank"><img src="images/logos/loggly.jpg" class="img-responsive"></a>
-                    <a href="http://www.premise.is/" target="blank"><img src="images/logos/premise.jpg" class="img-responsive"></a>
-                    
-                    <a href="http://www.iqyi.com/" target="blank"><img src="images/logos/qiy.jpg" class="img-responsive"></a>
-                    <a href="http://www.quicklizard.com/" target="blank"><img src="images/logos/quicklizard.jpg" class="img-responsive"></a>
-                    <a href="http://www.rocketfuel.com/" target="blank"><img src="images/logos/rocketfuel.jpg" class="img-responsive"></a>
-                    <a href="http://www.rubiconproject.com/" target="blank"><img src="images/logos/rubicon.jpg" class="img-responsive">
-                    </a>
-                    <a href="http://spider.io/" target="blank" ><img src="images/logos/spider.jpg" class="img-responsive"></a>
-                    <a href="http://www.taobao.com/" target="blank" ><img src="images/logos/taobao.jpg" class="img-responsive"></a>
-                    <a href="http://www.weather.com/" target="blank" ><img src="images/logos/the-weather-channel.jpg" class="img-responsive"></a>
-                    <a href="https://www.verisigninc.com/" target="blank" ><img src="images/logos/verisign.jpg" class="img-responsive"></a>
-                    <a href="http://www.webmd.com/" target="blank" ><img src="images/logos/webmd.jpg" class="img-responsive"></a>
-                    <a href="http://www.wego.com/"><img src="images/logos/wego.jpg" class="img-responsive"></a>
-                </div>
-                <div>
-                  <a href="/Powered-By.html" target="blank" class="pull-right" style="font-size: 18px;">and many others</a>
                 </div>
             </div>
         </div>

--- a/content/news.html
+++ b/content/news.html
@@ -100,6 +100,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Acking-framework-implementation.html
+++ b/content/releases/1.2.3/Acking-framework-implementation.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Classpath-handling.html
+++ b/content/releases/1.2.3/Classpath-handling.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Clojure-DSL.html
+++ b/content/releases/1.2.3/Clojure-DSL.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Command-line-client.html
+++ b/content/releases/1.2.3/Command-line-client.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Common-patterns.html
+++ b/content/releases/1.2.3/Common-patterns.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Concepts.html
+++ b/content/releases/1.2.3/Concepts.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Configuration.html
+++ b/content/releases/1.2.3/Configuration.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Contributing-to-Storm.html
+++ b/content/releases/1.2.3/Contributing-to-Storm.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Creating-a-new-Storm-project.html
+++ b/content/releases/1.2.3/Creating-a-new-Storm-project.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/DSLs-and-multilang-adapters.html
+++ b/content/releases/1.2.3/DSLs-and-multilang-adapters.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Daemon-Fault-Tolerance.html
+++ b/content/releases/1.2.3/Daemon-Fault-Tolerance.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Defining-a-non-jvm-language-dsl-for-storm.html
+++ b/content/releases/1.2.3/Defining-a-non-jvm-language-dsl-for-storm.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Distributed-RPC.html
+++ b/content/releases/1.2.3/Distributed-RPC.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Eventlogging.html
+++ b/content/releases/1.2.3/Eventlogging.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/FAQ.html
+++ b/content/releases/1.2.3/FAQ.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Fault-tolerance.html
+++ b/content/releases/1.2.3/Fault-tolerance.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Guaranteeing-message-processing.html
+++ b/content/releases/1.2.3/Guaranteeing-message-processing.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Hooks.html
+++ b/content/releases/1.2.3/Hooks.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Implementation-docs.html
+++ b/content/releases/1.2.3/Implementation-docs.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Installing-native-dependencies.html
+++ b/content/releases/1.2.3/Installing-native-dependencies.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Joins.html
+++ b/content/releases/1.2.3/Joins.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Kestrel-and-Storm.html
+++ b/content/releases/1.2.3/Kestrel-and-Storm.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Lifecycle-of-a-topology.html
+++ b/content/releases/1.2.3/Lifecycle-of-a-topology.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Local-mode.html
+++ b/content/releases/1.2.3/Local-mode.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Logs.html
+++ b/content/releases/1.2.3/Logs.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Maven.html
+++ b/content/releases/1.2.3/Maven.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Message-passing-implementation.html
+++ b/content/releases/1.2.3/Message-passing-implementation.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Metrics.html
+++ b/content/releases/1.2.3/Metrics.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Multilang-protocol.html
+++ b/content/releases/1.2.3/Multilang-protocol.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Pacemaker.html
+++ b/content/releases/1.2.3/Pacemaker.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Powered-By.html
+++ b/content/releases/1.2.3/Powered-By.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Project-ideas.html
+++ b/content/releases/1.2.3/Project-ideas.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Rationale.html
+++ b/content/releases/1.2.3/Rationale.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Resource_Aware_Scheduler_overview.html
+++ b/content/releases/1.2.3/Resource_Aware_Scheduler_overview.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Running-topologies-on-a-production-cluster.html
+++ b/content/releases/1.2.3/Running-topologies-on-a-production-cluster.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/SECURITY.html
+++ b/content/releases/1.2.3/SECURITY.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/STORM-UI-REST-API.html
+++ b/content/releases/1.2.3/STORM-UI-REST-API.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Serialization-(prior-to-0.6.0).html
+++ b/content/releases/1.2.3/Serialization-(prior-to-0.6.0).html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Serialization.html
+++ b/content/releases/1.2.3/Serialization.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Serializers.html
+++ b/content/releases/1.2.3/Serializers.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Setting-up-a-Storm-cluster.html
+++ b/content/releases/1.2.3/Setting-up-a-Storm-cluster.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Setting-up-development-environment.html
+++ b/content/releases/1.2.3/Setting-up-development-environment.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Spout-implementations.html
+++ b/content/releases/1.2.3/Spout-implementations.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/State-checkpointing.html
+++ b/content/releases/1.2.3/State-checkpointing.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Storm-Scheduler.html
+++ b/content/releases/1.2.3/Storm-Scheduler.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Storm-multi-language-protocol-(versions-0.7.0-and-below).html
+++ b/content/releases/1.2.3/Storm-multi-language-protocol-(versions-0.7.0-and-below).html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Structure-of-the-codebase.html
+++ b/content/releases/1.2.3/Structure-of-the-codebase.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Support-for-non-java-languages.html
+++ b/content/releases/1.2.3/Support-for-non-java-languages.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Transactional-topologies.html
+++ b/content/releases/1.2.3/Transactional-topologies.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Trident-API-Overview.html
+++ b/content/releases/1.2.3/Trident-API-Overview.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Trident-RAS-API.html
+++ b/content/releases/1.2.3/Trident-RAS-API.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Trident-spouts.html
+++ b/content/releases/1.2.3/Trident-spouts.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Trident-state.html
+++ b/content/releases/1.2.3/Trident-state.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Trident-tutorial.html
+++ b/content/releases/1.2.3/Trident-tutorial.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Troubleshooting.html
+++ b/content/releases/1.2.3/Troubleshooting.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Tutorial.html
+++ b/content/releases/1.2.3/Tutorial.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Understanding-the-parallelism-of-a-Storm-topology.html
+++ b/content/releases/1.2.3/Understanding-the-parallelism-of-a-Storm-topology.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Using-non-JVM-languages-with-Storm.html
+++ b/content/releases/1.2.3/Using-non-JVM-languages-with-Storm.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/Windowing.html
+++ b/content/releases/1.2.3/Windowing.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/distcache-blobstore.html
+++ b/content/releases/1.2.3/distcache-blobstore.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/dynamic-log-level-settings.html
+++ b/content/releases/1.2.3/dynamic-log-level-settings.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/dynamic-worker-profiling.html
+++ b/content/releases/1.2.3/dynamic-worker-profiling.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/flux.html
+++ b/content/releases/1.2.3/flux.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/index.html
+++ b/content/releases/1.2.3/index.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/metrics_v2.html
+++ b/content/releases/1.2.3/metrics_v2.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/nimbus-ha-design.html
+++ b/content/releases/1.2.3/nimbus-ha-design.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/storm-cassandra.html
+++ b/content/releases/1.2.3/storm-cassandra.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/storm-elasticsearch.html
+++ b/content/releases/1.2.3/storm-elasticsearch.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/storm-eventhubs.html
+++ b/content/releases/1.2.3/storm-eventhubs.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/storm-hbase.html
+++ b/content/releases/1.2.3/storm-hbase.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/storm-hdfs.html
+++ b/content/releases/1.2.3/storm-hdfs.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/storm-hive.html
+++ b/content/releases/1.2.3/storm-hive.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/storm-jdbc.html
+++ b/content/releases/1.2.3/storm-jdbc.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/storm-jms-example.html
+++ b/content/releases/1.2.3/storm-jms-example.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/storm-jms-spring.html
+++ b/content/releases/1.2.3/storm-jms-spring.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/storm-jms.html
+++ b/content/releases/1.2.3/storm-jms.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/storm-kafka-client.html
+++ b/content/releases/1.2.3/storm-kafka-client.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/storm-kafka.html
+++ b/content/releases/1.2.3/storm-kafka.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/storm-metrics-profiling-internal-actions.html
+++ b/content/releases/1.2.3/storm-metrics-profiling-internal-actions.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/storm-mongodb.html
+++ b/content/releases/1.2.3/storm-mongodb.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/storm-mqtt.html
+++ b/content/releases/1.2.3/storm-mqtt.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/storm-redis.html
+++ b/content/releases/1.2.3/storm-redis.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/storm-solr.html
+++ b/content/releases/1.2.3/storm-solr.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/storm-sql-example.html
+++ b/content/releases/1.2.3/storm-sql-example.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/storm-sql-internal.html
+++ b/content/releases/1.2.3/storm-sql-internal.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/storm-sql-reference.html
+++ b/content/releases/1.2.3/storm-sql-reference.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/storm-sql.html
+++ b/content/releases/1.2.3/storm-sql.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/1.2.3/windows-users-guide.html
+++ b/content/releases/1.2.3/windows-users-guide.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Acking-framework-implementation.html
+++ b/content/releases/2.0.0/Acking-framework-implementation.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Classpath-handling.html
+++ b/content/releases/2.0.0/Classpath-handling.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Clojure-DSL.html
+++ b/content/releases/2.0.0/Clojure-DSL.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/ClusterMetrics.html
+++ b/content/releases/2.0.0/ClusterMetrics.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Command-line-client.html
+++ b/content/releases/2.0.0/Command-line-client.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Common-patterns.html
+++ b/content/releases/2.0.0/Common-patterns.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Concepts.html
+++ b/content/releases/2.0.0/Concepts.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Configuration.html
+++ b/content/releases/2.0.0/Configuration.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Contributing-to-Storm.html
+++ b/content/releases/2.0.0/Contributing-to-Storm.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Creating-a-new-Storm-project.html
+++ b/content/releases/2.0.0/Creating-a-new-Storm-project.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/DSLs-and-multilang-adapters.html
+++ b/content/releases/2.0.0/DSLs-and-multilang-adapters.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Daemon-Fault-Tolerance.html
+++ b/content/releases/2.0.0/Daemon-Fault-Tolerance.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Defining-a-non-jvm-language-dsl-for-storm.html
+++ b/content/releases/2.0.0/Defining-a-non-jvm-language-dsl-for-storm.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Distributed-RPC.html
+++ b/content/releases/2.0.0/Distributed-RPC.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Eventlogging.html
+++ b/content/releases/2.0.0/Eventlogging.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/FAQ.html
+++ b/content/releases/2.0.0/FAQ.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Fault-tolerance.html
+++ b/content/releases/2.0.0/Fault-tolerance.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Guaranteeing-message-processing.html
+++ b/content/releases/2.0.0/Guaranteeing-message-processing.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Hooks.html
+++ b/content/releases/2.0.0/Hooks.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/IConfigLoader.html
+++ b/content/releases/2.0.0/IConfigLoader.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Implementation-docs.html
+++ b/content/releases/2.0.0/Implementation-docs.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Installing-native-dependencies.html
+++ b/content/releases/2.0.0/Installing-native-dependencies.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Joins.html
+++ b/content/releases/2.0.0/Joins.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Kestrel-and-Storm.html
+++ b/content/releases/2.0.0/Kestrel-and-Storm.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Lifecycle-of-a-topology.html
+++ b/content/releases/2.0.0/Lifecycle-of-a-topology.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Local-mode.html
+++ b/content/releases/2.0.0/Local-mode.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Logs.html
+++ b/content/releases/2.0.0/Logs.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Maven.html
+++ b/content/releases/2.0.0/Maven.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Message-passing-implementation.html
+++ b/content/releases/2.0.0/Message-passing-implementation.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Metrics.html
+++ b/content/releases/2.0.0/Metrics.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Multilang-protocol.html
+++ b/content/releases/2.0.0/Multilang-protocol.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Pacemaker.html
+++ b/content/releases/2.0.0/Pacemaker.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Performance.html
+++ b/content/releases/2.0.0/Performance.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Project-ideas.html
+++ b/content/releases/2.0.0/Project-ideas.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Rationale.html
+++ b/content/releases/2.0.0/Rationale.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Resource_Aware_Scheduler_overview.html
+++ b/content/releases/2.0.0/Resource_Aware_Scheduler_overview.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Running-topologies-on-a-production-cluster.html
+++ b/content/releases/2.0.0/Running-topologies-on-a-production-cluster.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/SECURITY.html
+++ b/content/releases/2.0.0/SECURITY.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/STORM-UI-REST-API.html
+++ b/content/releases/2.0.0/STORM-UI-REST-API.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Serialization-(prior-to-0.6.0).html
+++ b/content/releases/2.0.0/Serialization-(prior-to-0.6.0).html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Serialization.html
+++ b/content/releases/2.0.0/Serialization.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Serializers.html
+++ b/content/releases/2.0.0/Serializers.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Setting-up-a-Storm-cluster.html
+++ b/content/releases/2.0.0/Setting-up-a-Storm-cluster.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Setting-up-development-environment.html
+++ b/content/releases/2.0.0/Setting-up-development-environment.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Spout-implementations.html
+++ b/content/releases/2.0.0/Spout-implementations.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/State-checkpointing.html
+++ b/content/releases/2.0.0/State-checkpointing.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Storm-Scheduler.html
+++ b/content/releases/2.0.0/Storm-Scheduler.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Storm-multi-language-protocol-(versions-0.7.0-and-below).html
+++ b/content/releases/2.0.0/Storm-multi-language-protocol-(versions-0.7.0-and-below).html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Stream-API.html
+++ b/content/releases/2.0.0/Stream-API.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Structure-of-the-codebase.html
+++ b/content/releases/2.0.0/Structure-of-the-codebase.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Support-for-non-java-languages.html
+++ b/content/releases/2.0.0/Support-for-non-java-languages.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Transactional-topologies.html
+++ b/content/releases/2.0.0/Transactional-topologies.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Trident-API-Overview.html
+++ b/content/releases/2.0.0/Trident-API-Overview.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Trident-RAS-API.html
+++ b/content/releases/2.0.0/Trident-RAS-API.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Trident-spouts.html
+++ b/content/releases/2.0.0/Trident-spouts.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Trident-state.html
+++ b/content/releases/2.0.0/Trident-state.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Trident-tutorial.html
+++ b/content/releases/2.0.0/Trident-tutorial.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Troubleshooting.html
+++ b/content/releases/2.0.0/Troubleshooting.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Tutorial.html
+++ b/content/releases/2.0.0/Tutorial.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Understanding-the-parallelism-of-a-Storm-topology.html
+++ b/content/releases/2.0.0/Understanding-the-parallelism-of-a-Storm-topology.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Using-non-JVM-languages-with-Storm.html
+++ b/content/releases/2.0.0/Using-non-JVM-languages-with-Storm.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/Windowing.html
+++ b/content/releases/2.0.0/Windowing.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/cgroups_in_storm.html
+++ b/content/releases/2.0.0/cgroups_in_storm.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/distcache-blobstore.html
+++ b/content/releases/2.0.0/distcache-blobstore.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/dynamic-log-level-settings.html
+++ b/content/releases/2.0.0/dynamic-log-level-settings.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/dynamic-worker-profiling.html
+++ b/content/releases/2.0.0/dynamic-worker-profiling.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/flux.html
+++ b/content/releases/2.0.0/flux.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/index.html
+++ b/content/releases/2.0.0/index.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/metrics_v2.html
+++ b/content/releases/2.0.0/metrics_v2.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/nimbus-ha-design.html
+++ b/content/releases/2.0.0/nimbus-ha-design.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/storm-cassandra.html
+++ b/content/releases/2.0.0/storm-cassandra.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/storm-elasticsearch.html
+++ b/content/releases/2.0.0/storm-elasticsearch.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/storm-eventhubs.html
+++ b/content/releases/2.0.0/storm-eventhubs.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/storm-hbase.html
+++ b/content/releases/2.0.0/storm-hbase.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/storm-hdfs.html
+++ b/content/releases/2.0.0/storm-hdfs.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/storm-hive.html
+++ b/content/releases/2.0.0/storm-hive.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/storm-jdbc.html
+++ b/content/releases/2.0.0/storm-jdbc.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/storm-jms-example.html
+++ b/content/releases/2.0.0/storm-jms-example.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/storm-jms-spring.html
+++ b/content/releases/2.0.0/storm-jms-spring.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/storm-jms.html
+++ b/content/releases/2.0.0/storm-jms.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/storm-kafka-client.html
+++ b/content/releases/2.0.0/storm-kafka-client.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/storm-kinesis.html
+++ b/content/releases/2.0.0/storm-kinesis.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/storm-metricstore.html
+++ b/content/releases/2.0.0/storm-metricstore.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/storm-mongodb.html
+++ b/content/releases/2.0.0/storm-mongodb.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/storm-mqtt.html
+++ b/content/releases/2.0.0/storm-mqtt.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/storm-opentsdb.html
+++ b/content/releases/2.0.0/storm-opentsdb.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/storm-pmml.html
+++ b/content/releases/2.0.0/storm-pmml.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/storm-redis.html
+++ b/content/releases/2.0.0/storm-redis.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/storm-rocketmq.html
+++ b/content/releases/2.0.0/storm-rocketmq.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/storm-solr.html
+++ b/content/releases/2.0.0/storm-solr.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/storm-sql-example.html
+++ b/content/releases/2.0.0/storm-sql-example.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/storm-sql-internal.html
+++ b/content/releases/2.0.0/storm-sql-internal.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/storm-sql-reference.html
+++ b/content/releases/2.0.0/storm-sql-reference.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/storm-sql.html
+++ b/content/releases/2.0.0/storm-sql.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.0.0/windows-users-guide.html
+++ b/content/releases/2.0.0/windows-users-guide.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Acking-framework-implementation.html
+++ b/content/releases/2.1.0/Acking-framework-implementation.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Classpath-handling.html
+++ b/content/releases/2.1.0/Classpath-handling.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Clojure-DSL.html
+++ b/content/releases/2.1.0/Clojure-DSL.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/ClusterMetrics.html
+++ b/content/releases/2.1.0/ClusterMetrics.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Command-line-client.html
+++ b/content/releases/2.1.0/Command-line-client.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Common-patterns.html
+++ b/content/releases/2.1.0/Common-patterns.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Concepts.html
+++ b/content/releases/2.1.0/Concepts.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Configuration.html
+++ b/content/releases/2.1.0/Configuration.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Contributing-to-Storm.html
+++ b/content/releases/2.1.0/Contributing-to-Storm.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Creating-a-new-Storm-project.html
+++ b/content/releases/2.1.0/Creating-a-new-Storm-project.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/DSLs-and-multilang-adapters.html
+++ b/content/releases/2.1.0/DSLs-and-multilang-adapters.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Daemon-Fault-Tolerance.html
+++ b/content/releases/2.1.0/Daemon-Fault-Tolerance.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Defining-a-non-jvm-language-dsl-for-storm.html
+++ b/content/releases/2.1.0/Defining-a-non-jvm-language-dsl-for-storm.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Distributed-RPC.html
+++ b/content/releases/2.1.0/Distributed-RPC.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Eventlogging.html
+++ b/content/releases/2.1.0/Eventlogging.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/FAQ.html
+++ b/content/releases/2.1.0/FAQ.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Fault-tolerance.html
+++ b/content/releases/2.1.0/Fault-tolerance.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Guaranteeing-message-processing.html
+++ b/content/releases/2.1.0/Guaranteeing-message-processing.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Hooks.html
+++ b/content/releases/2.1.0/Hooks.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/IConfigLoader.html
+++ b/content/releases/2.1.0/IConfigLoader.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Implementation-docs.html
+++ b/content/releases/2.1.0/Implementation-docs.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Installing-native-dependencies.html
+++ b/content/releases/2.1.0/Installing-native-dependencies.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Joins.html
+++ b/content/releases/2.1.0/Joins.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Kestrel-and-Storm.html
+++ b/content/releases/2.1.0/Kestrel-and-Storm.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Lifecycle-of-a-topology.html
+++ b/content/releases/2.1.0/Lifecycle-of-a-topology.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Local-mode.html
+++ b/content/releases/2.1.0/Local-mode.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Logs.html
+++ b/content/releases/2.1.0/Logs.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Maven.html
+++ b/content/releases/2.1.0/Maven.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Message-passing-implementation.html
+++ b/content/releases/2.1.0/Message-passing-implementation.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Metrics.html
+++ b/content/releases/2.1.0/Metrics.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Multilang-protocol.html
+++ b/content/releases/2.1.0/Multilang-protocol.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Pacemaker.html
+++ b/content/releases/2.1.0/Pacemaker.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Performance.html
+++ b/content/releases/2.1.0/Performance.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Project-ideas.html
+++ b/content/releases/2.1.0/Project-ideas.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Rationale.html
+++ b/content/releases/2.1.0/Rationale.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Resource_Aware_Scheduler_overview.html
+++ b/content/releases/2.1.0/Resource_Aware_Scheduler_overview.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Running-topologies-on-a-production-cluster.html
+++ b/content/releases/2.1.0/Running-topologies-on-a-production-cluster.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/SECURITY.html
+++ b/content/releases/2.1.0/SECURITY.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/STORM-UI-REST-API.html
+++ b/content/releases/2.1.0/STORM-UI-REST-API.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Serialization-(prior-to-0.6.0).html
+++ b/content/releases/2.1.0/Serialization-(prior-to-0.6.0).html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Serialization.html
+++ b/content/releases/2.1.0/Serialization.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Serializers.html
+++ b/content/releases/2.1.0/Serializers.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Setting-up-a-Storm-cluster.html
+++ b/content/releases/2.1.0/Setting-up-a-Storm-cluster.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Setting-up-development-environment.html
+++ b/content/releases/2.1.0/Setting-up-development-environment.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Spout-implementations.html
+++ b/content/releases/2.1.0/Spout-implementations.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/State-checkpointing.html
+++ b/content/releases/2.1.0/State-checkpointing.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Storm-Scheduler.html
+++ b/content/releases/2.1.0/Storm-Scheduler.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Storm-multi-language-protocol-(versions-0.7.0-and-below).html
+++ b/content/releases/2.1.0/Storm-multi-language-protocol-(versions-0.7.0-and-below).html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Stream-API.html
+++ b/content/releases/2.1.0/Stream-API.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Structure-of-the-codebase.html
+++ b/content/releases/2.1.0/Structure-of-the-codebase.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Support-for-non-java-languages.html
+++ b/content/releases/2.1.0/Support-for-non-java-languages.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Transactional-topologies.html
+++ b/content/releases/2.1.0/Transactional-topologies.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Trident-API-Overview.html
+++ b/content/releases/2.1.0/Trident-API-Overview.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Trident-RAS-API.html
+++ b/content/releases/2.1.0/Trident-RAS-API.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Trident-spouts.html
+++ b/content/releases/2.1.0/Trident-spouts.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Trident-state.html
+++ b/content/releases/2.1.0/Trident-state.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Trident-tutorial.html
+++ b/content/releases/2.1.0/Trident-tutorial.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Troubleshooting.html
+++ b/content/releases/2.1.0/Troubleshooting.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Tutorial.html
+++ b/content/releases/2.1.0/Tutorial.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Understanding-the-parallelism-of-a-Storm-topology.html
+++ b/content/releases/2.1.0/Understanding-the-parallelism-of-a-Storm-topology.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Using-non-JVM-languages-with-Storm.html
+++ b/content/releases/2.1.0/Using-non-JVM-languages-with-Storm.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/Windowing.html
+++ b/content/releases/2.1.0/Windowing.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/cgroups_in_storm.html
+++ b/content/releases/2.1.0/cgroups_in_storm.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/distcache-blobstore.html
+++ b/content/releases/2.1.0/distcache-blobstore.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/dynamic-log-level-settings.html
+++ b/content/releases/2.1.0/dynamic-log-level-settings.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/dynamic-worker-profiling.html
+++ b/content/releases/2.1.0/dynamic-worker-profiling.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/flux.html
+++ b/content/releases/2.1.0/flux.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/index.html
+++ b/content/releases/2.1.0/index.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/metrics_v2.html
+++ b/content/releases/2.1.0/metrics_v2.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/nimbus-ha-design.html
+++ b/content/releases/2.1.0/nimbus-ha-design.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/storm-cassandra.html
+++ b/content/releases/2.1.0/storm-cassandra.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/storm-elasticsearch.html
+++ b/content/releases/2.1.0/storm-elasticsearch.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/storm-eventhubs.html
+++ b/content/releases/2.1.0/storm-eventhubs.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/storm-hbase.html
+++ b/content/releases/2.1.0/storm-hbase.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/storm-hdfs.html
+++ b/content/releases/2.1.0/storm-hdfs.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/storm-hive.html
+++ b/content/releases/2.1.0/storm-hive.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/storm-jdbc.html
+++ b/content/releases/2.1.0/storm-jdbc.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/storm-jms-example.html
+++ b/content/releases/2.1.0/storm-jms-example.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/storm-jms-spring.html
+++ b/content/releases/2.1.0/storm-jms-spring.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/storm-jms.html
+++ b/content/releases/2.1.0/storm-jms.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/storm-kafka-client.html
+++ b/content/releases/2.1.0/storm-kafka-client.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/storm-kinesis.html
+++ b/content/releases/2.1.0/storm-kinesis.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/storm-metricstore.html
+++ b/content/releases/2.1.0/storm-metricstore.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/storm-mongodb.html
+++ b/content/releases/2.1.0/storm-mongodb.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/storm-mqtt.html
+++ b/content/releases/2.1.0/storm-mqtt.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/storm-opentsdb.html
+++ b/content/releases/2.1.0/storm-opentsdb.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/storm-pmml.html
+++ b/content/releases/2.1.0/storm-pmml.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/storm-redis.html
+++ b/content/releases/2.1.0/storm-redis.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/storm-rocketmq.html
+++ b/content/releases/2.1.0/storm-rocketmq.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/storm-solr.html
+++ b/content/releases/2.1.0/storm-solr.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/storm-sql-example.html
+++ b/content/releases/2.1.0/storm-sql-example.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/storm-sql-internal.html
+++ b/content/releases/2.1.0/storm-sql-internal.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/storm-sql-reference.html
+++ b/content/releases/2.1.0/storm-sql-reference.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/storm-sql.html
+++ b/content/releases/2.1.0/storm-sql.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.1.0/windows-users-guide.html
+++ b/content/releases/2.1.0/windows-users-guide.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Acking-framework-implementation.html
+++ b/content/releases/2.2.0/Acking-framework-implementation.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Classpath-handling.html
+++ b/content/releases/2.2.0/Classpath-handling.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Clojure-DSL.html
+++ b/content/releases/2.2.0/Clojure-DSL.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/ClusterMetrics.html
+++ b/content/releases/2.2.0/ClusterMetrics.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Command-line-client.html
+++ b/content/releases/2.2.0/Command-line-client.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Common-patterns.html
+++ b/content/releases/2.2.0/Common-patterns.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Concepts.html
+++ b/content/releases/2.2.0/Concepts.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Configuration.html
+++ b/content/releases/2.2.0/Configuration.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Contributing-to-Storm.html
+++ b/content/releases/2.2.0/Contributing-to-Storm.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Creating-a-new-Storm-project.html
+++ b/content/releases/2.2.0/Creating-a-new-Storm-project.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/DSLs-and-multilang-adapters.html
+++ b/content/releases/2.2.0/DSLs-and-multilang-adapters.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Daemon-Fault-Tolerance.html
+++ b/content/releases/2.2.0/Daemon-Fault-Tolerance.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Defining-a-non-jvm-language-dsl-for-storm.html
+++ b/content/releases/2.2.0/Defining-a-non-jvm-language-dsl-for-storm.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Distributed-RPC.html
+++ b/content/releases/2.2.0/Distributed-RPC.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Eventlogging.html
+++ b/content/releases/2.2.0/Eventlogging.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/FAQ.html
+++ b/content/releases/2.2.0/FAQ.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Fault-tolerance.html
+++ b/content/releases/2.2.0/Fault-tolerance.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Generic-resources.html
+++ b/content/releases/2.2.0/Generic-resources.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Guaranteeing-message-processing.html
+++ b/content/releases/2.2.0/Guaranteeing-message-processing.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Hooks.html
+++ b/content/releases/2.2.0/Hooks.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/IConfigLoader.html
+++ b/content/releases/2.2.0/IConfigLoader.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Implementation-docs.html
+++ b/content/releases/2.2.0/Implementation-docs.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Installing-native-dependencies.html
+++ b/content/releases/2.2.0/Installing-native-dependencies.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Joins.html
+++ b/content/releases/2.2.0/Joins.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Kestrel-and-Storm.html
+++ b/content/releases/2.2.0/Kestrel-and-Storm.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Lifecycle-of-a-topology.html
+++ b/content/releases/2.2.0/Lifecycle-of-a-topology.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Local-mode.html
+++ b/content/releases/2.2.0/Local-mode.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Logs.html
+++ b/content/releases/2.2.0/Logs.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Maven.html
+++ b/content/releases/2.2.0/Maven.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Message-passing-implementation.html
+++ b/content/releases/2.2.0/Message-passing-implementation.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Metrics.html
+++ b/content/releases/2.2.0/Metrics.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Multilang-protocol.html
+++ b/content/releases/2.2.0/Multilang-protocol.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/NUMA.html
+++ b/content/releases/2.2.0/NUMA.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Pacemaker.html
+++ b/content/releases/2.2.0/Pacemaker.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Performance.html
+++ b/content/releases/2.2.0/Performance.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Project-ideas.html
+++ b/content/releases/2.2.0/Project-ideas.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Rationale.html
+++ b/content/releases/2.2.0/Rationale.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Resource_Aware_Scheduler_overview.html
+++ b/content/releases/2.2.0/Resource_Aware_Scheduler_overview.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Running-topologies-on-a-production-cluster.html
+++ b/content/releases/2.2.0/Running-topologies-on-a-production-cluster.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/SECURITY.html
+++ b/content/releases/2.2.0/SECURITY.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/STORM-UI-REST-API.html
+++ b/content/releases/2.2.0/STORM-UI-REST-API.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Serialization-(prior-to-0.6.0).html
+++ b/content/releases/2.2.0/Serialization-(prior-to-0.6.0).html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Serialization.html
+++ b/content/releases/2.2.0/Serialization.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Serializers.html
+++ b/content/releases/2.2.0/Serializers.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Setting-up-a-Storm-cluster.html
+++ b/content/releases/2.2.0/Setting-up-a-Storm-cluster.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Setting-up-development-environment.html
+++ b/content/releases/2.2.0/Setting-up-development-environment.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Spout-implementations.html
+++ b/content/releases/2.2.0/Spout-implementations.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/State-checkpointing.html
+++ b/content/releases/2.2.0/State-checkpointing.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Storm-Scheduler.html
+++ b/content/releases/2.2.0/Storm-Scheduler.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Storm-multi-language-protocol-(versions-0.7.0-and-below).html
+++ b/content/releases/2.2.0/Storm-multi-language-protocol-(versions-0.7.0-and-below).html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Stream-API.html
+++ b/content/releases/2.2.0/Stream-API.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Structure-of-the-codebase.html
+++ b/content/releases/2.2.0/Structure-of-the-codebase.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Support-for-non-java-languages.html
+++ b/content/releases/2.2.0/Support-for-non-java-languages.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Transactional-topologies.html
+++ b/content/releases/2.2.0/Transactional-topologies.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Trident-API-Overview.html
+++ b/content/releases/2.2.0/Trident-API-Overview.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Trident-RAS-API.html
+++ b/content/releases/2.2.0/Trident-RAS-API.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Trident-spouts.html
+++ b/content/releases/2.2.0/Trident-spouts.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Trident-state.html
+++ b/content/releases/2.2.0/Trident-state.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Trident-tutorial.html
+++ b/content/releases/2.2.0/Trident-tutorial.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Troubleshooting.html
+++ b/content/releases/2.2.0/Troubleshooting.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Tutorial.html
+++ b/content/releases/2.2.0/Tutorial.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Understanding-the-parallelism-of-a-Storm-topology.html
+++ b/content/releases/2.2.0/Understanding-the-parallelism-of-a-Storm-topology.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Using-non-JVM-languages-with-Storm.html
+++ b/content/releases/2.2.0/Using-non-JVM-languages-with-Storm.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/Windowing.html
+++ b/content/releases/2.2.0/Windowing.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/cgroups_in_storm.html
+++ b/content/releases/2.2.0/cgroups_in_storm.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/distcache-blobstore.html
+++ b/content/releases/2.2.0/distcache-blobstore.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/dynamic-log-level-settings.html
+++ b/content/releases/2.2.0/dynamic-log-level-settings.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/dynamic-worker-profiling.html
+++ b/content/releases/2.2.0/dynamic-worker-profiling.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/flux.html
+++ b/content/releases/2.2.0/flux.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/index.html
+++ b/content/releases/2.2.0/index.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/metrics_v2.html
+++ b/content/releases/2.2.0/metrics_v2.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/nimbus-ha-design.html
+++ b/content/releases/2.2.0/nimbus-ha-design.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/storm-cassandra.html
+++ b/content/releases/2.2.0/storm-cassandra.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/storm-elasticsearch.html
+++ b/content/releases/2.2.0/storm-elasticsearch.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/storm-eventhubs.html
+++ b/content/releases/2.2.0/storm-eventhubs.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/storm-hbase.html
+++ b/content/releases/2.2.0/storm-hbase.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/storm-hdfs.html
+++ b/content/releases/2.2.0/storm-hdfs.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/storm-hive.html
+++ b/content/releases/2.2.0/storm-hive.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/storm-jdbc.html
+++ b/content/releases/2.2.0/storm-jdbc.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/storm-jms-example.html
+++ b/content/releases/2.2.0/storm-jms-example.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/storm-jms-spring.html
+++ b/content/releases/2.2.0/storm-jms-spring.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/storm-jms.html
+++ b/content/releases/2.2.0/storm-jms.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/storm-kafka-client.html
+++ b/content/releases/2.2.0/storm-kafka-client.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/storm-kinesis.html
+++ b/content/releases/2.2.0/storm-kinesis.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/storm-metricstore.html
+++ b/content/releases/2.2.0/storm-metricstore.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/storm-mongodb.html
+++ b/content/releases/2.2.0/storm-mongodb.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/storm-mqtt.html
+++ b/content/releases/2.2.0/storm-mqtt.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/storm-opentsdb.html
+++ b/content/releases/2.2.0/storm-opentsdb.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/storm-pmml.html
+++ b/content/releases/2.2.0/storm-pmml.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/storm-redis.html
+++ b/content/releases/2.2.0/storm-redis.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/storm-rocketmq.html
+++ b/content/releases/2.2.0/storm-rocketmq.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/storm-solr.html
+++ b/content/releases/2.2.0/storm-solr.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/storm-sql-example.html
+++ b/content/releases/2.2.0/storm-sql-example.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/storm-sql-internal.html
+++ b/content/releases/2.2.0/storm-sql-internal.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/storm-sql-reference.html
+++ b/content/releases/2.2.0/storm-sql-reference.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/storm-sql.html
+++ b/content/releases/2.2.0/storm-sql.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.2.0/windows-users-guide.html
+++ b/content/releases/2.2.0/windows-users-guide.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Acking-framework-implementation.html
+++ b/content/releases/2.3.0/Acking-framework-implementation.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Classpath-handling.html
+++ b/content/releases/2.3.0/Classpath-handling.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Clojure-DSL.html
+++ b/content/releases/2.3.0/Clojure-DSL.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/ClusterMetrics.html
+++ b/content/releases/2.3.0/ClusterMetrics.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Command-line-client.html
+++ b/content/releases/2.3.0/Command-line-client.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Common-patterns.html
+++ b/content/releases/2.3.0/Common-patterns.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Concepts.html
+++ b/content/releases/2.3.0/Concepts.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Configuration.html
+++ b/content/releases/2.3.0/Configuration.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Contributing-to-Storm.html
+++ b/content/releases/2.3.0/Contributing-to-Storm.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Creating-a-new-Storm-project.html
+++ b/content/releases/2.3.0/Creating-a-new-Storm-project.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/DSLs-and-multilang-adapters.html
+++ b/content/releases/2.3.0/DSLs-and-multilang-adapters.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Daemon-Fault-Tolerance.html
+++ b/content/releases/2.3.0/Daemon-Fault-Tolerance.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Defining-a-non-jvm-language-dsl-for-storm.html
+++ b/content/releases/2.3.0/Defining-a-non-jvm-language-dsl-for-storm.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Distributed-RPC.html
+++ b/content/releases/2.3.0/Distributed-RPC.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Docker-support.html
+++ b/content/releases/2.3.0/Docker-support.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Eventlogging.html
+++ b/content/releases/2.3.0/Eventlogging.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/FAQ.html
+++ b/content/releases/2.3.0/FAQ.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Fault-tolerance.html
+++ b/content/releases/2.3.0/Fault-tolerance.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Generic-resources.html
+++ b/content/releases/2.3.0/Generic-resources.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Guaranteeing-message-processing.html
+++ b/content/releases/2.3.0/Guaranteeing-message-processing.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Hooks.html
+++ b/content/releases/2.3.0/Hooks.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/IConfigLoader.html
+++ b/content/releases/2.3.0/IConfigLoader.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Implementation-docs.html
+++ b/content/releases/2.3.0/Implementation-docs.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Installing-native-dependencies.html
+++ b/content/releases/2.3.0/Installing-native-dependencies.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Joins.html
+++ b/content/releases/2.3.0/Joins.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Kestrel-and-Storm.html
+++ b/content/releases/2.3.0/Kestrel-and-Storm.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Lifecycle-of-a-topology.html
+++ b/content/releases/2.3.0/Lifecycle-of-a-topology.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Local-mode.html
+++ b/content/releases/2.3.0/Local-mode.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/LocalityAwareness.html
+++ b/content/releases/2.3.0/LocalityAwareness.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Logs.html
+++ b/content/releases/2.3.0/Logs.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Maven.html
+++ b/content/releases/2.3.0/Maven.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Message-passing-implementation.html
+++ b/content/releases/2.3.0/Message-passing-implementation.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Metrics.html
+++ b/content/releases/2.3.0/Metrics.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Multilang-protocol.html
+++ b/content/releases/2.3.0/Multilang-protocol.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/NUMA.html
+++ b/content/releases/2.3.0/NUMA.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/OCI-support.html
+++ b/content/releases/2.3.0/OCI-support.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Pacemaker.html
+++ b/content/releases/2.3.0/Pacemaker.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Performance.html
+++ b/content/releases/2.3.0/Performance.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Project-ideas.html
+++ b/content/releases/2.3.0/Project-ideas.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Rationale.html
+++ b/content/releases/2.3.0/Rationale.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Resource_Aware_Scheduler_overview.html
+++ b/content/releases/2.3.0/Resource_Aware_Scheduler_overview.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Running-topologies-on-a-production-cluster.html
+++ b/content/releases/2.3.0/Running-topologies-on-a-production-cluster.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/SECURITY.html
+++ b/content/releases/2.3.0/SECURITY.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/STORM-UI-REST-API.html
+++ b/content/releases/2.3.0/STORM-UI-REST-API.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Serialization-(prior-to-0.6.0).html
+++ b/content/releases/2.3.0/Serialization-(prior-to-0.6.0).html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Serialization.html
+++ b/content/releases/2.3.0/Serialization.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Serializers.html
+++ b/content/releases/2.3.0/Serializers.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Setting-up-a-Storm-cluster.html
+++ b/content/releases/2.3.0/Setting-up-a-Storm-cluster.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Setting-up-development-environment.html
+++ b/content/releases/2.3.0/Setting-up-development-environment.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Spout-implementations.html
+++ b/content/releases/2.3.0/Spout-implementations.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/State-checkpointing.html
+++ b/content/releases/2.3.0/State-checkpointing.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Storm-Scheduler.html
+++ b/content/releases/2.3.0/Storm-Scheduler.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Storm-multi-language-protocol-(versions-0.7.0-and-below).html
+++ b/content/releases/2.3.0/Storm-multi-language-protocol-(versions-0.7.0-and-below).html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Stream-API.html
+++ b/content/releases/2.3.0/Stream-API.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Structure-of-the-codebase.html
+++ b/content/releases/2.3.0/Structure-of-the-codebase.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Support-for-non-java-languages.html
+++ b/content/releases/2.3.0/Support-for-non-java-languages.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Transactional-topologies.html
+++ b/content/releases/2.3.0/Transactional-topologies.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Trident-API-Overview.html
+++ b/content/releases/2.3.0/Trident-API-Overview.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Trident-RAS-API.html
+++ b/content/releases/2.3.0/Trident-RAS-API.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Trident-spouts.html
+++ b/content/releases/2.3.0/Trident-spouts.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Trident-state.html
+++ b/content/releases/2.3.0/Trident-state.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Trident-tutorial.html
+++ b/content/releases/2.3.0/Trident-tutorial.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Troubleshooting.html
+++ b/content/releases/2.3.0/Troubleshooting.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Tutorial.html
+++ b/content/releases/2.3.0/Tutorial.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Understanding-the-parallelism-of-a-Storm-topology.html
+++ b/content/releases/2.3.0/Understanding-the-parallelism-of-a-Storm-topology.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Using-non-JVM-languages-with-Storm.html
+++ b/content/releases/2.3.0/Using-non-JVM-languages-with-Storm.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/Windowing.html
+++ b/content/releases/2.3.0/Windowing.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/cgroups_in_storm.html
+++ b/content/releases/2.3.0/cgroups_in_storm.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/distcache-blobstore.html
+++ b/content/releases/2.3.0/distcache-blobstore.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/dynamic-log-level-settings.html
+++ b/content/releases/2.3.0/dynamic-log-level-settings.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/dynamic-worker-profiling.html
+++ b/content/releases/2.3.0/dynamic-worker-profiling.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/flux.html
+++ b/content/releases/2.3.0/flux.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/index.html
+++ b/content/releases/2.3.0/index.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/metrics_v2.html
+++ b/content/releases/2.3.0/metrics_v2.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/nimbus-ha-design.html
+++ b/content/releases/2.3.0/nimbus-ha-design.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/storm-cassandra.html
+++ b/content/releases/2.3.0/storm-cassandra.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/storm-elasticsearch.html
+++ b/content/releases/2.3.0/storm-elasticsearch.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/storm-eventhubs.html
+++ b/content/releases/2.3.0/storm-eventhubs.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/storm-hbase.html
+++ b/content/releases/2.3.0/storm-hbase.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/storm-hdfs.html
+++ b/content/releases/2.3.0/storm-hdfs.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/storm-hive.html
+++ b/content/releases/2.3.0/storm-hive.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/storm-jdbc.html
+++ b/content/releases/2.3.0/storm-jdbc.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/storm-jms-example.html
+++ b/content/releases/2.3.0/storm-jms-example.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/storm-jms-spring.html
+++ b/content/releases/2.3.0/storm-jms-spring.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/storm-jms.html
+++ b/content/releases/2.3.0/storm-jms.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/storm-kafka-client.html
+++ b/content/releases/2.3.0/storm-kafka-client.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/storm-kinesis.html
+++ b/content/releases/2.3.0/storm-kinesis.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/storm-metricstore.html
+++ b/content/releases/2.3.0/storm-metricstore.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/storm-mongodb.html
+++ b/content/releases/2.3.0/storm-mongodb.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/storm-mqtt.html
+++ b/content/releases/2.3.0/storm-mqtt.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/storm-opentsdb.html
+++ b/content/releases/2.3.0/storm-opentsdb.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/storm-pmml.html
+++ b/content/releases/2.3.0/storm-pmml.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/storm-redis.html
+++ b/content/releases/2.3.0/storm-redis.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/storm-rocketmq.html
+++ b/content/releases/2.3.0/storm-rocketmq.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/storm-solr.html
+++ b/content/releases/2.3.0/storm-solr.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/storm-sql-example.html
+++ b/content/releases/2.3.0/storm-sql-example.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/storm-sql-internal.html
+++ b/content/releases/2.3.0/storm-sql-internal.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/storm-sql-reference.html
+++ b/content/releases/2.3.0/storm-sql-reference.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/storm-sql.html
+++ b/content/releases/2.3.0/storm-sql.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/2.3.0/windows-users-guide.html
+++ b/content/releases/2.3.0/windows-users-guide.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Acking-framework-implementation.html
+++ b/content/releases/current/Acking-framework-implementation.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Classpath-handling.html
+++ b/content/releases/current/Classpath-handling.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Clojure-DSL.html
+++ b/content/releases/current/Clojure-DSL.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/ClusterMetrics.html
+++ b/content/releases/current/ClusterMetrics.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Command-line-client.html
+++ b/content/releases/current/Command-line-client.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Common-patterns.html
+++ b/content/releases/current/Common-patterns.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Concepts.html
+++ b/content/releases/current/Concepts.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Configuration.html
+++ b/content/releases/current/Configuration.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Contributing-to-Storm.html
+++ b/content/releases/current/Contributing-to-Storm.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Creating-a-new-Storm-project.html
+++ b/content/releases/current/Creating-a-new-Storm-project.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/DSLs-and-multilang-adapters.html
+++ b/content/releases/current/DSLs-and-multilang-adapters.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Daemon-Fault-Tolerance.html
+++ b/content/releases/current/Daemon-Fault-Tolerance.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Defining-a-non-jvm-language-dsl-for-storm.html
+++ b/content/releases/current/Defining-a-non-jvm-language-dsl-for-storm.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Distributed-RPC.html
+++ b/content/releases/current/Distributed-RPC.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Docker-support.html
+++ b/content/releases/current/Docker-support.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Eventlogging.html
+++ b/content/releases/current/Eventlogging.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/FAQ.html
+++ b/content/releases/current/FAQ.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Fault-tolerance.html
+++ b/content/releases/current/Fault-tolerance.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Generic-resources.html
+++ b/content/releases/current/Generic-resources.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Guaranteeing-message-processing.html
+++ b/content/releases/current/Guaranteeing-message-processing.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Hooks.html
+++ b/content/releases/current/Hooks.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/IConfigLoader.html
+++ b/content/releases/current/IConfigLoader.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Implementation-docs.html
+++ b/content/releases/current/Implementation-docs.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Installing-native-dependencies.html
+++ b/content/releases/current/Installing-native-dependencies.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Joins.html
+++ b/content/releases/current/Joins.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Kestrel-and-Storm.html
+++ b/content/releases/current/Kestrel-and-Storm.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Lifecycle-of-a-topology.html
+++ b/content/releases/current/Lifecycle-of-a-topology.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Local-mode.html
+++ b/content/releases/current/Local-mode.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/LocalityAwareness.html
+++ b/content/releases/current/LocalityAwareness.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Logs.html
+++ b/content/releases/current/Logs.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Maven.html
+++ b/content/releases/current/Maven.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Message-passing-implementation.html
+++ b/content/releases/current/Message-passing-implementation.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Metrics.html
+++ b/content/releases/current/Metrics.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Multilang-protocol.html
+++ b/content/releases/current/Multilang-protocol.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/NUMA.html
+++ b/content/releases/current/NUMA.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/OCI-support.html
+++ b/content/releases/current/OCI-support.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Pacemaker.html
+++ b/content/releases/current/Pacemaker.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Performance.html
+++ b/content/releases/current/Performance.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Project-ideas.html
+++ b/content/releases/current/Project-ideas.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Rationale.html
+++ b/content/releases/current/Rationale.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Resource_Aware_Scheduler_overview.html
+++ b/content/releases/current/Resource_Aware_Scheduler_overview.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Running-topologies-on-a-production-cluster.html
+++ b/content/releases/current/Running-topologies-on-a-production-cluster.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/SECURITY.html
+++ b/content/releases/current/SECURITY.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/STORM-UI-REST-API.html
+++ b/content/releases/current/STORM-UI-REST-API.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Serialization-(prior-to-0.6.0).html
+++ b/content/releases/current/Serialization-(prior-to-0.6.0).html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Serialization.html
+++ b/content/releases/current/Serialization.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Serializers.html
+++ b/content/releases/current/Serializers.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Setting-up-a-Storm-cluster.html
+++ b/content/releases/current/Setting-up-a-Storm-cluster.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Setting-up-development-environment.html
+++ b/content/releases/current/Setting-up-development-environment.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Spout-implementations.html
+++ b/content/releases/current/Spout-implementations.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/State-checkpointing.html
+++ b/content/releases/current/State-checkpointing.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Storm-Scheduler.html
+++ b/content/releases/current/Storm-Scheduler.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Storm-multi-language-protocol-(versions-0.7.0-and-below).html
+++ b/content/releases/current/Storm-multi-language-protocol-(versions-0.7.0-and-below).html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Stream-API.html
+++ b/content/releases/current/Stream-API.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Structure-of-the-codebase.html
+++ b/content/releases/current/Structure-of-the-codebase.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Support-for-non-java-languages.html
+++ b/content/releases/current/Support-for-non-java-languages.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Transactional-topologies.html
+++ b/content/releases/current/Transactional-topologies.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Trident-API-Overview.html
+++ b/content/releases/current/Trident-API-Overview.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Trident-RAS-API.html
+++ b/content/releases/current/Trident-RAS-API.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Trident-spouts.html
+++ b/content/releases/current/Trident-spouts.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Trident-state.html
+++ b/content/releases/current/Trident-state.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Trident-tutorial.html
+++ b/content/releases/current/Trident-tutorial.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Troubleshooting.html
+++ b/content/releases/current/Troubleshooting.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Tutorial.html
+++ b/content/releases/current/Tutorial.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Understanding-the-parallelism-of-a-Storm-topology.html
+++ b/content/releases/current/Understanding-the-parallelism-of-a-Storm-topology.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Using-non-JVM-languages-with-Storm.html
+++ b/content/releases/current/Using-non-JVM-languages-with-Storm.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/Windowing.html
+++ b/content/releases/current/Windowing.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/cgroups_in_storm.html
+++ b/content/releases/current/cgroups_in_storm.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/distcache-blobstore.html
+++ b/content/releases/current/distcache-blobstore.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/dynamic-log-level-settings.html
+++ b/content/releases/current/dynamic-log-level-settings.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/dynamic-worker-profiling.html
+++ b/content/releases/current/dynamic-worker-profiling.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/flux.html
+++ b/content/releases/current/flux.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/index.html
+++ b/content/releases/current/index.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/metrics_v2.html
+++ b/content/releases/current/metrics_v2.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/nimbus-ha-design.html
+++ b/content/releases/current/nimbus-ha-design.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/storm-cassandra.html
+++ b/content/releases/current/storm-cassandra.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/storm-elasticsearch.html
+++ b/content/releases/current/storm-elasticsearch.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/storm-eventhubs.html
+++ b/content/releases/current/storm-eventhubs.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/storm-hbase.html
+++ b/content/releases/current/storm-hbase.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/storm-hdfs.html
+++ b/content/releases/current/storm-hdfs.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/storm-hive.html
+++ b/content/releases/current/storm-hive.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/storm-jdbc.html
+++ b/content/releases/current/storm-jdbc.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/storm-jms-example.html
+++ b/content/releases/current/storm-jms-example.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/storm-jms-spring.html
+++ b/content/releases/current/storm-jms-spring.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/storm-jms.html
+++ b/content/releases/current/storm-jms.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/storm-kafka-client.html
+++ b/content/releases/current/storm-kafka-client.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/storm-kinesis.html
+++ b/content/releases/current/storm-kinesis.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/storm-metricstore.html
+++ b/content/releases/current/storm-metricstore.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/storm-mongodb.html
+++ b/content/releases/current/storm-mongodb.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/storm-mqtt.html
+++ b/content/releases/current/storm-mqtt.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/storm-opentsdb.html
+++ b/content/releases/current/storm-opentsdb.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/storm-pmml.html
+++ b/content/releases/current/storm-pmml.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/storm-redis.html
+++ b/content/releases/current/storm-redis.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/storm-rocketmq.html
+++ b/content/releases/current/storm-rocketmq.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/storm-solr.html
+++ b/content/releases/current/storm-solr.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/storm-sql-example.html
+++ b/content/releases/current/storm-sql-example.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/storm-sql-internal.html
+++ b/content/releases/current/storm-sql-internal.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/storm-sql-reference.html
+++ b/content/releases/current/storm-sql-reference.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/storm-sql.html
+++ b/content/releases/current/storm-sql.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/releases/current/windows-users-guide.html
+++ b/content/releases/current/windows-users-guide.html
@@ -102,6 +102,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/content/talksAndVideos.html
+++ b/content/talksAndVideos.html
@@ -100,6 +100,7 @@
                         <li><a href="/contribute/Contributing-to-Storm.html">Contributing</a></li>
                         <li><a href="/contribute/People.html">People</a></li>
                         <li><a href="/contribute/BYLAWS.html">ByLaws</a></li>
+                        <li><a href="/Powered-By.html">PoweredBy</a></li>
                     </ul>
                 </li>
                 <li><a href="/2021/09/27/storm230-released.html" id="news">News</a></li>

--- a/index.html
+++ b/index.html
@@ -56,45 +56,6 @@ title: Apache Storm
                 </div>
             </div>
         </div>
-        <div class="row">
-          <div class="col-md-12">
-              <div id="owl-example" class="owl-carousel">
-                    <a href="http://www.yahoo.com/" target="blank"><img src="images/logos/yahoo.png" class="img-responsive"></a>
-                    <a href="http://www.twitter.com/" target="blank"><img src="images/logos/twitter.jpg" class="img-responsive"></a>
-                    <a href="http://www.spotify.com/" target="blank"><img src="images/logos/spotify.jpg" class="img-responsive"></a>
-                    <a href="http://www.yahoo.co.jp/" target="blank"><img src="images/logos/yahoo-japan.jpg" class="img-responsive"></a>
-                    <a href="http://www.yelp.com/" target="blank"><img src="images/logos/yelp.jpg" class="img-responsive"></a>
-                    <a href="http://flipboard.com/" target="blank"><img src="images/logos/flipboard.jpg" class="img-responsive"></a>
-                    <a href="http://www.ooyala.com/" target="blank"><img src="images/logos/ooyala.jpg" class="img-responsive"></a>
-                    <a href="http://groupon.com/" target="blank"><img src="images/logos/groupon.jpg" class="img-responsive"></a>
-                    <a href="http://www.parc.com/" target="blank"><img src="images/logos/parc.png" class="img-responsive"></a>
-                    <a href="http://www.alibaba.com/" target="blank"><img src="images/logos/alibaba.jpg" class="img-responsive"></a>
-                    <a href="http://www.baidu.com/" target="blank"><img src="images/logos/bai.jpg" class="img-responsive"></a>
-                    <a href="http://www.cerner.com/" target="blank"><img src="images/logos/cerner.jpg" class="img-responsive"></a>
-                    <a href="http://www.fullcontact.com/" target="blank"><img src="images/logos/fullcontact.jpg" class="img-responsive"></a>
-                    <a href="http://www.healthmarketscience.com/" target="blank"><img src="images/logos/health-market-science.jpg" class="img-responsive"></a>
-                    <a href="http://www.infochimps.com/" target="blank"><img src="images/logos/infochimp.jpg" class="img-responsive"></a>
-                    <a href="http://www.klout.com/" target="blank"><img src="images/logos/klout.jpg" class="img-responsive"></a>
-                    <a href="http://www.loggly.com/" target="blank"><img src="images/logos/loggly.jpg" class="img-responsive"></a>
-                    <a href="http://www.premise.is/" target="blank"><img src="images/logos/premise.jpg" class="img-responsive"></a>
-                    
-                    <a href="http://www.iqyi.com/" target="blank"><img src="images/logos/qiy.jpg" class="img-responsive"></a>
-                    <a href="http://www.quicklizard.com/" target="blank"><img src="images/logos/quicklizard.jpg" class="img-responsive"></a>
-                    <a href="http://www.rocketfuel.com/" target="blank"><img src="images/logos/rocketfuel.jpg" class="img-responsive"></a>
-                    <a href="http://www.rubiconproject.com/" target="blank"><img src="images/logos/rubicon.jpg" class="img-responsive">
-                    </a>
-                    <a href="http://spider.io/" target="blank" ><img src="images/logos/spider.jpg" class="img-responsive"></a>
-                    <a href="http://www.taobao.com/" target="blank" ><img src="images/logos/taobao.jpg" class="img-responsive"></a>
-                    <a href="http://www.weather.com/" target="blank" ><img src="images/logos/the-weather-channel.jpg" class="img-responsive"></a>
-                    <a href="https://www.verisigninc.com/" target="blank" ><img src="images/logos/verisign.jpg" class="img-responsive"></a>
-                    <a href="http://www.webmd.com/" target="blank" ><img src="images/logos/webmd.jpg" class="img-responsive"></a>
-                    <a href="http://www.wego.com/"><img src="images/logos/wego.jpg" class="img-responsive"></a>
-                </div>
-                <div>
-                  <a href="/Powered-By.html" target="blank" class="pull-right" style="font-size: 18px;">and many others</a>
-                </div>
-            </div>
-        </div>
     </div>
 </div>
 


### PR DESCRIPTION
As required by ASF, we shouldn't show company logs on the homepage. I am moving it to powered-by page and added a tab in the "Community" tab on the header.

See
<img width="1427" alt="Screen Shot 2021-09-27 at 4 41 30 PM" src="https://user-images.githubusercontent.com/14900612/134989427-ee0dcdef-4a9f-49ef-a4dc-09287b1ce058.png">

And on the powered-by page:

<img width="1198" alt="Screen Shot 2021-09-27 at 4 43 09 PM" src="https://user-images.githubusercontent.com/14900612/134989562-d09ca5a1-e25c-4d13-aaa5-d7a5fd889e66.png">


