### PR TITLE
Change copyright from 2019 to 2021

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -43,7 +43,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2012/08/02/storm080-released.html
+++ b/content/2012/08/02/storm080-released.html
@@ -419,7 +419,7 @@ topology.transfer.buffer.size </p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2012/09/06/storm081-released.html
+++ b/content/2012/09/06/storm081-released.html
@@ -353,7 +353,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2013/01/11/storm082-released.html
+++ b/content/2013/01/11/storm082-released.html
@@ -380,7 +380,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2013/12/08/storm090-released.html
+++ b/content/2013/12/08/storm090-released.html
@@ -417,7 +417,7 @@ storm.messaging.netty.min_wait_ms: 100
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2014/04/10/storm-logo-contest.html
+++ b/content/2014/04/10/storm-logo-contest.html
@@ -379,7 +379,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2014/04/17/logo-pforrest.html
+++ b/content/2014/04/17/logo-pforrest.html
@@ -316,7 +316,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2014/04/17/logo-squinones.html
+++ b/content/2014/04/17/logo-squinones.html
@@ -316,7 +316,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2014/04/19/logo-ssuleman.html
+++ b/content/2014/04/19/logo-ssuleman.html
@@ -314,7 +314,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2014/04/21/logo-rmarshall.html
+++ b/content/2014/04/21/logo-rmarshall.html
@@ -318,7 +318,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2014/04/22/logo-zsayari.html
+++ b/content/2014/04/22/logo-zsayari.html
@@ -314,7 +314,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2014/04/23/logo-abartos.html
+++ b/content/2014/04/23/logo-abartos.html
@@ -320,7 +320,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2014/04/27/logo-cboustead.html
+++ b/content/2014/04/27/logo-cboustead.html
@@ -316,7 +316,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2014/04/27/logo-sasili.html
+++ b/content/2014/04/27/logo-sasili.html
@@ -314,7 +314,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2014/04/29/logo-jlee1.html
+++ b/content/2014/04/29/logo-jlee1.html
@@ -314,7 +314,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2014/04/29/logo-jlee2.html
+++ b/content/2014/04/29/logo-jlee2.html
@@ -314,7 +314,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2014/04/29/logo-jlee3.html
+++ b/content/2014/04/29/logo-jlee3.html
@@ -314,7 +314,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2014/05/27/round1-results.html
+++ b/content/2014/05/27/round1-results.html
@@ -398,7 +398,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2014/06/17/contest-results.html
+++ b/content/2014/06/17/contest-results.html
@@ -348,7 +348,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2014/06/25/storm092-released.html
+++ b/content/2014/06/25/storm092-released.html
@@ -436,7 +436,7 @@ version: 0.9.2-incubating
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2014/10/20/storm093-release-candidate.html
+++ b/content/2014/10/20/storm093-release-candidate.html
@@ -316,7 +316,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2014/11/25/storm093-released.html
+++ b/content/2014/11/25/storm093-released.html
@@ -497,7 +497,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2015/03/25/storm094-released.html
+++ b/content/2015/03/25/storm094-released.html
@@ -328,7 +328,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2015/06/04/storm095-released.html
+++ b/content/2015/06/04/storm095-released.html
@@ -327,7 +327,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2015/06/15/storm0100-beta-released.html
+++ b/content/2015/06/15/storm0100-beta-released.html
@@ -595,7 +595,7 @@ that allows users to stream data from Apache Storm directly into hive. Apache St
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2015/11/05/storm0100-released.html
+++ b/content/2015/11/05/storm0100-released.html
@@ -358,7 +358,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2015/11/05/storm096-released.html
+++ b/content/2015/11/05/storm096-released.html
@@ -333,7 +333,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2016/04/12/storm100-released.html
+++ b/content/2016/04/12/storm100-released.html
@@ -725,7 +725,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2016/05/05/storm0101-released.html
+++ b/content/2016/05/05/storm0101-released.html
@@ -333,7 +333,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2016/05/06/storm101-released.html
+++ b/content/2016/05/06/storm101-released.html
@@ -349,7 +349,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2016/08/10/storm102-released.html
+++ b/content/2016/08/10/storm102-released.html
@@ -373,7 +373,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2016/09/07/storm097-released.html
+++ b/content/2016/09/07/storm097-released.html
@@ -329,7 +329,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2016/09/14/storm0102-released.html
+++ b/content/2016/09/14/storm0102-released.html
@@ -332,7 +332,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2017/02/14/storm103-released.html
+++ b/content/2017/02/14/storm103-released.html
@@ -384,7 +384,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2017/03/29/storm110-released.html
+++ b/content/2017/03/29/storm110-released.html
@@ -643,7 +643,7 @@ Version: 1.1.0</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2017/07/28/storm104-released.html
+++ b/content/2017/07/28/storm104-released.html
@@ -352,7 +352,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2017/08/01/storm111-released.html
+++ b/content/2017/08/01/storm111-released.html
@@ -368,7 +368,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2017/09/15/storm105-released.html
+++ b/content/2017/09/15/storm105-released.html
@@ -338,7 +338,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2018/02/14/storm106-released.html
+++ b/content/2018/02/14/storm106-released.html
@@ -367,7 +367,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2018/02/15/storm112-released.html
+++ b/content/2018/02/15/storm112-released.html
@@ -403,7 +403,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2018/02/15/storm120-released.html
+++ b/content/2018/02/15/storm120-released.html
@@ -526,7 +526,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2018/02/19/storm121-released.html
+++ b/content/2018/02/19/storm121-released.html
@@ -336,7 +336,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2018/06/04/storm113-released.html
+++ b/content/2018/06/04/storm113-released.html
@@ -372,7 +372,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2018/06/04/storm122-released.html
+++ b/content/2018/06/04/storm122-released.html
@@ -372,7 +372,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2019/05/30/storm200-released.html
+++ b/content/2019/05/30/storm200-released.html
@@ -404,7 +404,7 @@ affect you. If you were using a custom Subscription, <a href="https://github.com
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2019/07/18/storm123-released.html
+++ b/content/2019/07/18/storm123-released.html
@@ -379,7 +379,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2019/10/31/storm210-released.html
+++ b/content/2019/10/31/storm210-released.html
@@ -426,7 +426,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2020/06/30/storm220-released.html
+++ b/content/2020/06/30/storm220-released.html
@@ -468,7 +468,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/2021/09/27/storm230-released.html
+++ b/content/2021/09/27/storm230-released.html
@@ -456,7 +456,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/Powered-By.html
+++ b/content/Powered-By.html
@@ -1271,7 +1271,7 @@ At XenonStack we use Storm for building real-time data integration systems and e
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/about/deployment.html
+++ b/content/about/deployment.html
@@ -221,7 +221,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/about/fault-tolerant.html
+++ b/content/about/fault-tolerant.html
@@ -223,7 +223,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/about/free-and-open-source.html
+++ b/content/about/free-and-open-source.html
@@ -230,7 +230,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/about/guarantees-data-processing.html
+++ b/content/about/guarantees-data-processing.html
@@ -223,7 +223,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/about/integrates.html
+++ b/content/about/integrates.html
@@ -229,7 +229,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/about/multi-language.html
+++ b/content/about/multi-language.html
@@ -223,7 +223,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/about/scalable.html
+++ b/content/about/scalable.html
@@ -226,7 +226,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/about/simple-api.html
+++ b/content/about/simple-api.html
@@ -229,7 +229,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/contribute/BYLAWS.html
+++ b/content/contribute/BYLAWS.html
@@ -394,7 +394,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/contribute/Contributing-to-Storm.html
+++ b/content/contribute/Contributing-to-Storm.html
@@ -205,7 +205,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/contribute/People.html
+++ b/content/contribute/People.html
@@ -496,7 +496,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/downloads.html
+++ b/content/downloads.html
@@ -324,7 +324,7 @@ version: 1.2.3</pre>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/feed.xml
+++ b/content/feed.xml
@@ -5,8 +5,8 @@
     <description></description>
     <link>http://storm.apache.org/</link>
     <atom:link href="http://storm.apache.org/feed.xml" rel="self" type="application/rss+xml"/>
-    <pubDate>Mon, 27 Sep 2021 16:36:29 -0500</pubDate>
-    <lastBuildDate>Mon, 27 Sep 2021 16:36:29 -0500</lastBuildDate>
+    <pubDate>Tue, 28 Sep 2021 10:50:16 -0500</pubDate>
+    <lastBuildDate>Tue, 28 Sep 2021 10:50:16 -0500</lastBuildDate>
     <generator>Jekyll v3.6.2</generator>
     
       <item>

--- a/content/getting-help.html
+++ b/content/getting-help.html
@@ -217,7 +217,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/index.html
+++ b/content/index.html
@@ -242,7 +242,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/news.html
+++ b/content/news.html
@@ -286,7 +286,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Acking-framework-implementation.html
+++ b/content/releases/1.2.3/Acking-framework-implementation.html
@@ -218,7 +218,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Classpath-handling.html
+++ b/content/releases/1.2.3/Classpath-handling.html
@@ -211,7 +211,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Clojure-DSL.html
+++ b/content/releases/1.2.3/Clojure-DSL.html
@@ -409,7 +409,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Command-line-client.html
+++ b/content/releases/1.2.3/Command-line-client.html
@@ -461,7 +461,7 @@ and timeout is integer seconds.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Common-patterns.html
+++ b/content/releases/1.2.3/Common-patterns.html
@@ -250,7 +250,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Concepts.html
+++ b/content/releases/1.2.3/Concepts.html
@@ -306,7 +306,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Configuration.html
+++ b/content/releases/1.2.3/Configuration.html
@@ -213,7 +213,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Contributing-to-Storm.html
+++ b/content/releases/1.2.3/Contributing-to-Storm.html
@@ -210,7 +210,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Creating-a-new-Storm-project.html
+++ b/content/releases/1.2.3/Creating-a-new-Storm-project.html
@@ -204,7 +204,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/DSLs-and-multilang-adapters.html
+++ b/content/releases/1.2.3/DSLs-and-multilang-adapters.html
@@ -189,7 +189,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Daemon-Fault-Tolerance.html
+++ b/content/releases/1.2.3/Daemon-Fault-Tolerance.html
@@ -207,7 +207,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Defining-a-non-jvm-language-dsl-for-storm.html
+++ b/content/releases/1.2.3/Defining-a-non-jvm-language-dsl-for-storm.html
@@ -203,7 +203,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Distributed-RPC.html
+++ b/content/releases/1.2.3/Distributed-RPC.html
@@ -375,7 +375,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Eventlogging.html
+++ b/content/releases/1.2.3/Eventlogging.html
@@ -307,7 +307,7 @@ One of idea to avoid this is making your implementation of IEventLogger as <code
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/FAQ.html
+++ b/content/releases/1.2.3/FAQ.html
@@ -314,7 +314,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Fault-tolerance.html
+++ b/content/releases/1.2.3/Fault-tolerance.html
@@ -207,7 +207,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Guaranteeing-message-processing.html
+++ b/content/releases/1.2.3/Guaranteeing-message-processing.html
@@ -339,7 +339,7 @@ This page describes how Storm can guarantee at least once processing.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Hooks.html
+++ b/content/releases/1.2.3/Hooks.html
@@ -194,7 +194,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Implementation-docs.html
+++ b/content/releases/1.2.3/Implementation-docs.html
@@ -192,7 +192,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Installing-native-dependencies.html
+++ b/content/releases/1.2.3/Installing-native-dependencies.html
@@ -213,7 +213,7 @@ sudo make install
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Joins.html
+++ b/content/releases/1.2.3/Joins.html
@@ -310,7 +310,7 @@ can occur when its value is set to null.</li>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Kestrel-and-Storm.html
+++ b/content/releases/1.2.3/Kestrel-and-Storm.html
@@ -372,7 +372,7 @@ If you run the topology with TOPOLOGY_DEBUG you should see tuples being emitted 
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Lifecycle-of-a-topology.html
+++ b/content/releases/1.2.3/Lifecycle-of-a-topology.html
@@ -299,7 +299,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Local-mode.html
+++ b/content/releases/1.2.3/Local-mode.html
@@ -202,7 +202,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Logs.html
+++ b/content/releases/1.2.3/Logs.html
@@ -209,7 +209,7 @@ Log Search supports searching in a certain log file or in all of a topology&#39;
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Maven.html
+++ b/content/releases/1.2.3/Maven.html
@@ -195,7 +195,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Message-passing-implementation.html
+++ b/content/releases/1.2.3/Message-passing-implementation.html
@@ -224,7 +224,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Metrics.html
+++ b/content/releases/1.2.3/Metrics.html
@@ -504,7 +504,7 @@ Prior to STORM-2621 (v1.1.1, v1.2.0, and v2.0.0) these were the rate of entries,
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Multilang-protocol.html
+++ b/content/releases/1.2.3/Multilang-protocol.html
@@ -474,7 +474,7 @@ ShellBolt.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Pacemaker.html
+++ b/content/releases/1.2.3/Pacemaker.html
@@ -296,7 +296,7 @@ On a 270 supervisor cluster, fully scheduled with topologies, Pacemaker resource
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Powered-By.html
+++ b/content/releases/1.2.3/Powered-By.html
@@ -1207,7 +1207,7 @@ We are using Storm to track internet threats from varied sources around the web.
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Project-ideas.html
+++ b/content/releases/1.2.3/Project-ideas.html
@@ -187,7 +187,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Rationale.html
+++ b/content/releases/1.2.3/Rationale.html
@@ -214,7 +214,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Resource_Aware_Scheduler_overview.html
+++ b/content/releases/1.2.3/Resource_Aware_Scheduler_overview.html
@@ -655,7 +655,7 @@ rack-0 Avail [ CPU 32.78688524590164% MEM 19.51219512195122% Slots 20.0% ] effec
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Running-topologies-on-a-production-cluster.html
+++ b/content/releases/1.2.3/Running-topologies-on-a-production-cluster.html
@@ -250,7 +250,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/SECURITY.html
+++ b/content/releases/1.2.3/SECURITY.html
@@ -745,7 +745,7 @@ on all possible worker hosts.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/STORM-UI-REST-API.html
+++ b/content/releases/1.2.3/STORM-UI-REST-API.html
@@ -2974,7 +2974,7 @@ daemons.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Serialization-(prior-to-0.6.0).html
+++ b/content/releases/1.2.3/Serialization-(prior-to-0.6.0).html
@@ -226,7 +226,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Serialization.html
+++ b/content/releases/1.2.3/Serialization.html
@@ -238,7 +238,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Serializers.html
+++ b/content/releases/1.2.3/Serializers.html
@@ -185,7 +185,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Setting-up-a-Storm-cluster.html
+++ b/content/releases/1.2.3/Setting-up-a-Storm-cluster.html
@@ -284,7 +284,7 @@ The time to allow any given healthcheck script to run before it is marked failed
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Setting-up-development-environment.html
+++ b/content/releases/1.2.3/Setting-up-development-environment.html
@@ -209,7 +209,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Spout-implementations.html
+++ b/content/releases/1.2.3/Spout-implementations.html
@@ -189,7 +189,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/State-checkpointing.html
+++ b/content/releases/1.2.3/State-checkpointing.html
@@ -457,7 +457,7 @@ Even if worker crashes at commit phase, after restart it will read pending-commi
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Storm-Scheduler.html
+++ b/content/releases/1.2.3/Storm-Scheduler.html
@@ -201,7 +201,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Storm-multi-language-protocol-(versions-0.7.0-and-below).html
+++ b/content/releases/1.2.3/Storm-multi-language-protocol-(versions-0.7.0-and-below).html
@@ -291,7 +291,7 @@ file lets the supervisor know the PID so it can shutdown the process later on.</
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Structure-of-the-codebase.html
+++ b/content/releases/1.2.3/Structure-of-the-codebase.html
@@ -325,7 +325,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Support-for-non-java-languages.html
+++ b/content/releases/1.2.3/Support-for-non-java-languages.html
@@ -188,7 +188,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Transactional-topologies.html
+++ b/content/releases/1.2.3/Transactional-topologies.html
@@ -548,7 +548,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Trident-API-Overview.html
+++ b/content/releases/1.2.3/Trident-API-Overview.html
@@ -707,7 +707,7 @@ Partition 2:
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Trident-RAS-API.html
+++ b/content/releases/1.2.3/Trident-RAS-API.html
@@ -230,7 +230,7 @@ Resources are declared per operation, but get combined within boundaries.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Trident-spouts.html
+++ b/content/releases/1.2.3/Trident-spouts.html
@@ -220,7 +220,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Trident-state.html
+++ b/content/releases/1.2.3/Trident-state.html
@@ -453,7 +453,7 @@ apple =&gt; [count=10, txid=2]
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Trident-tutorial.html
+++ b/content/releases/1.2.3/Trident-tutorial.html
@@ -394,7 +394,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Troubleshooting.html
+++ b/content/releases/1.2.3/Troubleshooting.html
@@ -317,7 +317,7 @@ Caused by: java.util.ConcurrentModificationException
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Tutorial.html
+++ b/content/releases/1.2.3/Tutorial.html
@@ -466,7 +466,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Understanding-the-parallelism-of-a-Storm-topology.html
+++ b/content/releases/1.2.3/Understanding-the-parallelism-of-a-Storm-topology.html
@@ -312,7 +312,7 @@ $ storm rebalance mytopology -n 5 -e blue-spout=3 -e yellow-bolt=10
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Using-non-JVM-languages-with-Storm.html
+++ b/content/releases/1.2.3/Using-non-JVM-languages-with-Storm.html
@@ -236,7 +236,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/Windowing.html
+++ b/content/releases/1.2.3/Windowing.html
@@ -418,7 +418,7 @@ average.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/distcache-blobstore.html
+++ b/content/releases/1.2.3/distcache-blobstore.html
@@ -837,7 +837,7 @@ struct BeginDownloadResult {
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/dynamic-log-level-settings.html
+++ b/content/releases/1.2.3/dynamic-log-level-settings.html
@@ -217,7 +217,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/dynamic-worker-profiling.html
+++ b/content/releases/1.2.3/dynamic-worker-profiling.html
@@ -209,7 +209,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/flux.html
+++ b/content/releases/1.2.3/flux.html
@@ -973,7 +973,7 @@ same file. Includes may be either files, or classpath resources.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/index.html
+++ b/content/releases/1.2.3/index.html
@@ -324,7 +324,7 @@ But small change will not affect the user experience. We will notify the user wh
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/metrics_v2.html
+++ b/content/releases/1.2.3/metrics_v2.html
@@ -310,7 +310,7 @@ interface:</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/nimbus-ha-design.html
+++ b/content/releases/1.2.3/nimbus-ha-design.html
@@ -399,7 +399,7 @@ So you should expect your topology submission time to be somewhere between 0 to 
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/storm-cassandra.html
+++ b/content/releases/1.2.3/storm-cassandra.html
@@ -411,7 +411,7 @@ The stream is partitioned among the bolt&#39;s tasks based on the specified row 
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/storm-elasticsearch.html
+++ b/content/releases/1.2.3/storm-elasticsearch.html
@@ -283,7 +283,7 @@ You can refer implementation of DefaultEsTupleMapper to see how to implement you
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/storm-eventhubs.html
+++ b/content/releases/1.2.3/storm-eventhubs.html
@@ -216,7 +216,7 @@ If you want to send messages to all partitions, use &quot;-1&quot; as partitionI
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/storm-hbase.html
+++ b/content/releases/1.2.3/storm-hbase.html
@@ -406,7 +406,7 @@ Word: 'watermelon', Count: 6806
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/storm-hdfs.html
+++ b/content/releases/1.2.3/storm-hdfs.html
@@ -507,7 +507,7 @@ to remember this as you bring up new hosts in the cluster.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/storm-hive.html
+++ b/content/releases/1.2.3/storm-hive.html
@@ -341,7 +341,7 @@ User should make sure that Tuple field names are matched to the table column nam
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/storm-jdbc.html
+++ b/content/releases/1.2.3/storm-jdbc.html
@@ -437,7 +437,7 @@ storm jar org.apache.storm.jdbc.topology.UserPersistanceTopology <dataSourceClas
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/storm-jms-example.html
+++ b/content/releases/1.2.3/storm-jms-example.html
@@ -286,7 +286,7 @@ DEBUG (backtype.storm.contrib.jms.spout.JmsSpout:251) - JMS Message acked: ID:bu
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/storm-jms-spring.html
+++ b/content/releases/1.2.3/storm-jms-spring.html
@@ -201,7 +201,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/storm-jms.html
+++ b/content/releases/1.2.3/storm-jms.html
@@ -207,7 +207,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/storm-kafka-client.html
+++ b/content/releases/1.2.3/storm-kafka-client.html
@@ -612,7 +612,7 @@ and Kafka 0.10.1.0 <a href="https://kafka.apache.org/0101/javadoc/index.html?org
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/storm-kafka.html
+++ b/content/releases/1.2.3/storm-kafka.html
@@ -541,7 +541,7 @@ Section &quot;Important configuration properties for the producer&quot; for more
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/storm-metrics-profiling-internal-actions.html
+++ b/content/releases/1.2.3/storm-metrics-profiling-internal-actions.html
@@ -249,7 +249,7 @@ supervisor.childopts: "-Xmx256m -Dcom.sun.management.jmxremote.port=3337 -Dcom.s
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/storm-mongodb.html
+++ b/content/releases/1.2.3/storm-mongodb.html
@@ -336,7 +336,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/storm-mqtt.html
+++ b/content/releases/1.2.3/storm-mqtt.html
@@ -521,7 +521,7 @@ keystore/truststore need to be available on all worker nodes where the spout/bol
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/storm-redis.html
+++ b/content/releases/1.2.3/storm-redis.html
@@ -420,7 +420,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/storm-solr.html
+++ b/content/releases/1.2.3/storm-solr.html
@@ -346,7 +346,7 @@ and then generate an uber jar with all the dependencies.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/storm-sql-example.html
+++ b/content/releases/1.2.3/storm-sql-example.html
@@ -417,7 +417,7 @@ This page assumes that GetTime2 is in classpath, for simplicity.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/storm-sql-internal.html
+++ b/content/releases/1.2.3/storm-sql-internal.html
@@ -233,7 +233,7 @@ You can use <code>--jars</code> or <code>--artifacts</code> option to <code>stor
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/storm-sql-reference.html
+++ b/content/releases/1.2.3/storm-sql-reference.html
@@ -2139,7 +2139,7 @@ You can put the <code>core-site.xml</code> and <code>hdfs-site.xml</code> into t
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/storm-sql.html
+++ b/content/releases/1.2.3/storm-sql.html
@@ -322,7 +322,7 @@ LogicalTableModify(table=[[LARGE_ORDERS]], operation=[INSERT], updateColumnList=
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/1.2.3/windows-users-guide.html
+++ b/content/releases/1.2.3/windows-users-guide.html
@@ -210,7 +210,7 @@ created as a convienence, so it is not a 100% backwards compatible change.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Acking-framework-implementation.html
+++ b/content/releases/2.0.0/Acking-framework-implementation.html
@@ -218,7 +218,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Classpath-handling.html
+++ b/content/releases/2.0.0/Classpath-handling.html
@@ -211,7 +211,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Clojure-DSL.html
+++ b/content/releases/2.0.0/Clojure-DSL.html
@@ -409,7 +409,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/ClusterMetrics.html
+++ b/content/releases/2.0.0/ClusterMetrics.html
@@ -1237,7 +1237,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Command-line-client.html
+++ b/content/releases/2.0.0/Command-line-client.html
@@ -535,7 +535,7 @@ and timeout is integer seconds.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Common-patterns.html
+++ b/content/releases/2.0.0/Common-patterns.html
@@ -250,7 +250,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Concepts.html
+++ b/content/releases/2.0.0/Concepts.html
@@ -310,7 +310,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Configuration.html
+++ b/content/releases/2.0.0/Configuration.html
@@ -225,7 +225,7 @@ the name of your Config class.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Contributing-to-Storm.html
+++ b/content/releases/2.0.0/Contributing-to-Storm.html
@@ -210,7 +210,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Creating-a-new-Storm-project.html
+++ b/content/releases/2.0.0/Creating-a-new-Storm-project.html
@@ -204,7 +204,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/DSLs-and-multilang-adapters.html
+++ b/content/releases/2.0.0/DSLs-and-multilang-adapters.html
@@ -190,7 +190,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Daemon-Fault-Tolerance.html
+++ b/content/releases/2.0.0/Daemon-Fault-Tolerance.html
@@ -207,7 +207,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Defining-a-non-jvm-language-dsl-for-storm.html
+++ b/content/releases/2.0.0/Defining-a-non-jvm-language-dsl-for-storm.html
@@ -203,7 +203,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Distributed-RPC.html
+++ b/content/releases/2.0.0/Distributed-RPC.html
@@ -385,7 +385,7 @@ try (DRPCClient drpc = DRPCClient.getConfiguredClient(conf)) {
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Eventlogging.html
+++ b/content/releases/2.0.0/Eventlogging.html
@@ -307,7 +307,7 @@ One of idea to avoid this is making your implementation of IEventLogger as <code
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/FAQ.html
+++ b/content/releases/2.0.0/FAQ.html
@@ -314,7 +314,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Fault-tolerance.html
+++ b/content/releases/2.0.0/Fault-tolerance.html
@@ -207,7 +207,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Guaranteeing-message-processing.html
+++ b/content/releases/2.0.0/Guaranteeing-message-processing.html
@@ -339,7 +339,7 @@ This page describes how Storm can guarantee at least once processing.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Hooks.html
+++ b/content/releases/2.0.0/Hooks.html
@@ -194,7 +194,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/IConfigLoader.html
+++ b/content/releases/2.0.0/IConfigLoader.html
@@ -233,7 +233,7 @@ For <code>FileConfigLoader</code>, this is the URI pointing to a file.</li>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Implementation-docs.html
+++ b/content/releases/2.0.0/Implementation-docs.html
@@ -193,7 +193,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Installing-native-dependencies.html
+++ b/content/releases/2.0.0/Installing-native-dependencies.html
@@ -213,7 +213,7 @@ sudo make install
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Joins.html
+++ b/content/releases/2.0.0/Joins.html
@@ -310,7 +310,7 @@ can occur when its value is set to null.</li>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Kestrel-and-Storm.html
+++ b/content/releases/2.0.0/Kestrel-and-Storm.html
@@ -371,7 +371,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Lifecycle-of-a-topology.html
+++ b/content/releases/2.0.0/Lifecycle-of-a-topology.html
@@ -299,7 +299,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Local-mode.html
+++ b/content/releases/2.0.0/Local-mode.html
@@ -253,7 +253,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Logs.html
+++ b/content/releases/2.0.0/Logs.html
@@ -209,7 +209,7 @@ Log Search supports searching in a certain log file or in all of a topology&#39;
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Maven.html
+++ b/content/releases/2.0.0/Maven.html
@@ -195,7 +195,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Message-passing-implementation.html
+++ b/content/releases/2.0.0/Message-passing-implementation.html
@@ -224,7 +224,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Metrics.html
+++ b/content/releases/2.0.0/Metrics.html
@@ -514,7 +514,7 @@ Prior to STORM-2621 (v1.1.1, v1.2.0, and v2.0.0) these were the rate of entries,
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Multilang-protocol.html
+++ b/content/releases/2.0.0/Multilang-protocol.html
@@ -490,7 +490,7 @@ ShellBolt.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Pacemaker.html
+++ b/content/releases/2.0.0/Pacemaker.html
@@ -291,7 +291,7 @@ On a 270 supervisor cluster, fully scheduled with topologies, Pacemaker resource
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Performance.html
+++ b/content/releases/2.0.0/Performance.html
@@ -363,7 +363,7 @@ The downside to this approach is that it adds the overhead of monitoring and man
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Project-ideas.html
+++ b/content/releases/2.0.0/Project-ideas.html
@@ -187,7 +187,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Rationale.html
+++ b/content/releases/2.0.0/Rationale.html
@@ -214,7 +214,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Resource_Aware_Scheduler_overview.html
+++ b/content/releases/2.0.0/Resource_Aware_Scheduler_overview.html
@@ -729,7 +729,7 @@ The effective resource of a rack, which is also the subordinate resource, is com
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Running-topologies-on-a-production-cluster.html
+++ b/content/releases/2.0.0/Running-topologies-on-a-production-cluster.html
@@ -250,7 +250,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/SECURITY.html
+++ b/content/releases/2.0.0/SECURITY.html
@@ -809,7 +809,7 @@ on all possible worker hosts.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/STORM-UI-REST-API.html
+++ b/content/releases/2.0.0/STORM-UI-REST-API.html
@@ -3150,7 +3150,7 @@ to use the POST option instead.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Serialization-(prior-to-0.6.0).html
+++ b/content/releases/2.0.0/Serialization-(prior-to-0.6.0).html
@@ -226,7 +226,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Serialization.html
+++ b/content/releases/2.0.0/Serialization.html
@@ -244,7 +244,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Serializers.html
+++ b/content/releases/2.0.0/Serializers.html
@@ -185,7 +185,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Setting-up-a-Storm-cluster.html
+++ b/content/releases/2.0.0/Setting-up-a-Storm-cluster.html
@@ -298,7 +298,7 @@ The time to allow any given healthcheck script to run before it is marked failed
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Setting-up-development-environment.html
+++ b/content/releases/2.0.0/Setting-up-development-environment.html
@@ -209,7 +209,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Spout-implementations.html
+++ b/content/releases/2.0.0/Spout-implementations.html
@@ -189,7 +189,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/State-checkpointing.html
+++ b/content/releases/2.0.0/State-checkpointing.html
@@ -459,7 +459,7 @@ Even if worker crashes at commit phase, after restart it will read pending-commi
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Storm-Scheduler.html
+++ b/content/releases/2.0.0/Storm-Scheduler.html
@@ -201,7 +201,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Storm-multi-language-protocol-(versions-0.7.0-and-below).html
+++ b/content/releases/2.0.0/Storm-multi-language-protocol-(versions-0.7.0-and-below).html
@@ -291,7 +291,7 @@ file lets the supervisor know the PID so it can shutdown the process later on.</
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Stream-API.html
+++ b/content/releases/2.0.0/Stream-API.html
@@ -603,7 +603,7 @@ via <code>build()</code> and submit it like a normal storm topology via <code>St
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Structure-of-the-codebase.html
+++ b/content/releases/2.0.0/Structure-of-the-codebase.html
@@ -313,7 +313,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Support-for-non-java-languages.html
+++ b/content/releases/2.0.0/Support-for-non-java-languages.html
@@ -188,7 +188,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Transactional-topologies.html
+++ b/content/releases/2.0.0/Transactional-topologies.html
@@ -548,7 +548,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Trident-API-Overview.html
+++ b/content/releases/2.0.0/Trident-API-Overview.html
@@ -707,7 +707,7 @@ Partition 2:
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Trident-RAS-API.html
+++ b/content/releases/2.0.0/Trident-RAS-API.html
@@ -230,7 +230,7 @@ Resources are declared per operation, but get combined within boundaries.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Trident-spouts.html
+++ b/content/releases/2.0.0/Trident-spouts.html
@@ -220,7 +220,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Trident-state.html
+++ b/content/releases/2.0.0/Trident-state.html
@@ -453,7 +453,7 @@ apple =&gt; [count=10, txid=2]
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Trident-tutorial.html
+++ b/content/releases/2.0.0/Trident-tutorial.html
@@ -396,7 +396,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Troubleshooting.html
+++ b/content/releases/2.0.0/Troubleshooting.html
@@ -317,7 +317,7 @@ Caused by: java.util.ConcurrentModificationException
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Tutorial.html
+++ b/content/releases/2.0.0/Tutorial.html
@@ -440,7 +440,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Understanding-the-parallelism-of-a-Storm-topology.html
+++ b/content/releases/2.0.0/Understanding-the-parallelism-of-a-Storm-topology.html
@@ -312,7 +312,7 @@ $ storm rebalance mytopology -n 5 -e blue-spout=3 -e yellow-bolt=10
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Using-non-JVM-languages-with-Storm.html
+++ b/content/releases/2.0.0/Using-non-JVM-languages-with-Storm.html
@@ -236,7 +236,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/Windowing.html
+++ b/content/releases/2.0.0/Windowing.html
@@ -517,7 +517,7 @@ which will help you get started.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/cgroups_in_storm.html
+++ b/content/releases/2.0.0/cgroups_in_storm.html
@@ -353,7 +353,7 @@ out.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/distcache-blobstore.html
+++ b/content/releases/2.0.0/distcache-blobstore.html
@@ -837,7 +837,7 @@ struct BeginDownloadResult {
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/dynamic-log-level-settings.html
+++ b/content/releases/2.0.0/dynamic-log-level-settings.html
@@ -217,7 +217,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/dynamic-worker-profiling.html
+++ b/content/releases/2.0.0/dynamic-worker-profiling.html
@@ -209,7 +209,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/flux.html
+++ b/content/releases/2.0.0/flux.html
@@ -951,7 +951,7 @@ same file. Includes may be either files, or classpath resources.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/index.html
+++ b/content/releases/2.0.0/index.html
@@ -326,7 +326,7 @@ But small change will not affect the user experience. We will notify the user wh
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/metrics_v2.html
+++ b/content/releases/2.0.0/metrics_v2.html
@@ -310,7 +310,7 @@ interface:</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/nimbus-ha-design.html
+++ b/content/releases/2.0.0/nimbus-ha-design.html
@@ -399,7 +399,7 @@ So you should expect your topology submission time to be somewhere between 0 to 
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/storm-cassandra.html
+++ b/content/releases/2.0.0/storm-cassandra.html
@@ -411,7 +411,7 @@ The stream is partitioned among the bolt&#39;s tasks based on the specified row 
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/storm-elasticsearch.html
+++ b/content/releases/2.0.0/storm-elasticsearch.html
@@ -283,7 +283,7 @@ You can refer implementation of DefaultEsTupleMapper to see how to implement you
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/storm-eventhubs.html
+++ b/content/releases/2.0.0/storm-eventhubs.html
@@ -216,7 +216,7 @@ If you want to send messages to all partitions, use &quot;-1&quot; as partitionI
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/storm-hbase.html
+++ b/content/releases/2.0.0/storm-hbase.html
@@ -433,7 +433,7 @@ Word: 'watermelon', Count: 6806
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/storm-hdfs.html
+++ b/content/releases/2.0.0/storm-hdfs.html
@@ -783,7 +783,7 @@ However, the later mechanism is deprecated as it does not allow multiple Hdfs sp
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/storm-hive.html
+++ b/content/releases/2.0.0/storm-hive.html
@@ -341,7 +341,7 @@ User should make sure that Tuple field names are matched to the table column nam
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/storm-jdbc.html
+++ b/content/releases/2.0.0/storm-jdbc.html
@@ -437,7 +437,7 @@ storm jar org.apache.storm.jdbc.topology.UserPersistanceTopology <dataSourceClas
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/storm-jms-example.html
+++ b/content/releases/2.0.0/storm-jms-example.html
@@ -286,7 +286,7 @@ DEBUG (backtype.storm.contrib.jms.spout.JmsSpout:251) - JMS Message acked: ID:bu
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/storm-jms-spring.html
+++ b/content/releases/2.0.0/storm-jms-spring.html
@@ -201,7 +201,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/storm-jms.html
+++ b/content/releases/2.0.0/storm-jms.html
@@ -207,7 +207,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/storm-kafka-client.html
+++ b/content/releases/2.0.0/storm-kafka-client.html
@@ -571,7 +571,7 @@ and Kafka 0.10.1.0 <a href="https://kafka.apache.org/0101/javadoc/index.html?org
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/storm-kinesis.html
+++ b/content/releases/2.0.0/storm-kinesis.html
@@ -321,7 +321,7 @@ However, storm can still call next tuple on the spout because there is only 1 pe
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/storm-metricstore.html
+++ b/content/releases/2.0.0/storm-metricstore.html
@@ -369,7 +369,7 @@ fields are as follows:</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/storm-mongodb.html
+++ b/content/releases/2.0.0/storm-mongodb.html
@@ -455,7 +455,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/storm-mqtt.html
+++ b/content/releases/2.0.0/storm-mqtt.html
@@ -521,7 +521,7 @@ keystore/truststore need to be available on all worker nodes where the spout/bol
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/storm-opentsdb.html
+++ b/content/releases/2.0.0/storm-opentsdb.html
@@ -226,7 +226,7 @@ configured HBase cluster to push/query the data.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/storm-pmml.html
+++ b/content/releases/2.0.0/storm-pmml.html
@@ -213,7 +213,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/storm-redis.html
+++ b/content/releases/2.0.0/storm-redis.html
@@ -420,7 +420,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/storm-rocketmq.html
+++ b/content/releases/2.0.0/storm-rocketmq.html
@@ -264,7 +264,7 @@ RocketMqBolt send messages async by default. You can change this by invoking <co
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/storm-solr.html
+++ b/content/releases/2.0.0/storm-solr.html
@@ -346,7 +346,7 @@ and then generate an uber jar with all the dependencies.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/storm-sql-example.html
+++ b/content/releases/2.0.0/storm-sql-example.html
@@ -412,7 +412,7 @@ This page assumes that GetTime2 is in classpath, for simplicity.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/storm-sql-internal.html
+++ b/content/releases/2.0.0/storm-sql-internal.html
@@ -233,7 +233,7 @@ You can use <code>--jars</code> or <code>--artifacts</code> option to <code>stor
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/storm-sql-reference.html
+++ b/content/releases/2.0.0/storm-sql-reference.html
@@ -2140,7 +2140,7 @@ You can put the <code>core-site.xml</code> and <code>hdfs-site.xml</code> into t
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/storm-sql.html
+++ b/content/releases/2.0.0/storm-sql.html
@@ -349,7 +349,7 @@ public class Generated_STREAMSCALCREL_33_0 implements org.apache.storm.sql.runti
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.0.0/windows-users-guide.html
+++ b/content/releases/2.0.0/windows-users-guide.html
@@ -210,7 +210,7 @@ created as a convienence, so it is not a 100% backwards compatible change.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Acking-framework-implementation.html
+++ b/content/releases/2.1.0/Acking-framework-implementation.html
@@ -218,7 +218,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Classpath-handling.html
+++ b/content/releases/2.1.0/Classpath-handling.html
@@ -211,7 +211,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Clojure-DSL.html
+++ b/content/releases/2.1.0/Clojure-DSL.html
@@ -409,7 +409,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/ClusterMetrics.html
+++ b/content/releases/2.1.0/ClusterMetrics.html
@@ -1237,7 +1237,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Command-line-client.html
+++ b/content/releases/2.1.0/Command-line-client.html
@@ -535,7 +535,7 @@ and timeout is integer seconds.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Common-patterns.html
+++ b/content/releases/2.1.0/Common-patterns.html
@@ -250,7 +250,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Concepts.html
+++ b/content/releases/2.1.0/Concepts.html
@@ -310,7 +310,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Configuration.html
+++ b/content/releases/2.1.0/Configuration.html
@@ -225,7 +225,7 @@ the name of your Config class.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Contributing-to-Storm.html
+++ b/content/releases/2.1.0/Contributing-to-Storm.html
@@ -210,7 +210,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Creating-a-new-Storm-project.html
+++ b/content/releases/2.1.0/Creating-a-new-Storm-project.html
@@ -204,7 +204,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/DSLs-and-multilang-adapters.html
+++ b/content/releases/2.1.0/DSLs-and-multilang-adapters.html
@@ -190,7 +190,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Daemon-Fault-Tolerance.html
+++ b/content/releases/2.1.0/Daemon-Fault-Tolerance.html
@@ -207,7 +207,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Defining-a-non-jvm-language-dsl-for-storm.html
+++ b/content/releases/2.1.0/Defining-a-non-jvm-language-dsl-for-storm.html
@@ -203,7 +203,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Distributed-RPC.html
+++ b/content/releases/2.1.0/Distributed-RPC.html
@@ -385,7 +385,7 @@ try (DRPCClient drpc = DRPCClient.getConfiguredClient(conf)) {
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Eventlogging.html
+++ b/content/releases/2.1.0/Eventlogging.html
@@ -307,7 +307,7 @@ One of idea to avoid this is making your implementation of IEventLogger as <code
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/FAQ.html
+++ b/content/releases/2.1.0/FAQ.html
@@ -314,7 +314,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Fault-tolerance.html
+++ b/content/releases/2.1.0/Fault-tolerance.html
@@ -207,7 +207,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Guaranteeing-message-processing.html
+++ b/content/releases/2.1.0/Guaranteeing-message-processing.html
@@ -339,7 +339,7 @@ This page describes how Storm can guarantee at least once processing.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Hooks.html
+++ b/content/releases/2.1.0/Hooks.html
@@ -194,7 +194,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/IConfigLoader.html
+++ b/content/releases/2.1.0/IConfigLoader.html
@@ -233,7 +233,7 @@ For <code>FileConfigLoader</code>, this is the URI pointing to a file.</li>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Implementation-docs.html
+++ b/content/releases/2.1.0/Implementation-docs.html
@@ -193,7 +193,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Installing-native-dependencies.html
+++ b/content/releases/2.1.0/Installing-native-dependencies.html
@@ -213,7 +213,7 @@ sudo make install
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Joins.html
+++ b/content/releases/2.1.0/Joins.html
@@ -310,7 +310,7 @@ can occur when its value is set to null.</li>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Kestrel-and-Storm.html
+++ b/content/releases/2.1.0/Kestrel-and-Storm.html
@@ -371,7 +371,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Lifecycle-of-a-topology.html
+++ b/content/releases/2.1.0/Lifecycle-of-a-topology.html
@@ -299,7 +299,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Local-mode.html
+++ b/content/releases/2.1.0/Local-mode.html
@@ -253,7 +253,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Logs.html
+++ b/content/releases/2.1.0/Logs.html
@@ -209,7 +209,7 @@ Log Search supports searching in a certain log file or in all of a topology&#39;
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Maven.html
+++ b/content/releases/2.1.0/Maven.html
@@ -195,7 +195,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Message-passing-implementation.html
+++ b/content/releases/2.1.0/Message-passing-implementation.html
@@ -224,7 +224,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Metrics.html
+++ b/content/releases/2.1.0/Metrics.html
@@ -514,7 +514,7 @@ Prior to STORM-2621 (v1.1.1, v1.2.0, and v2.0.0) these were the rate of entries,
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Multilang-protocol.html
+++ b/content/releases/2.1.0/Multilang-protocol.html
@@ -490,7 +490,7 @@ ShellBolt.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Pacemaker.html
+++ b/content/releases/2.1.0/Pacemaker.html
@@ -291,7 +291,7 @@ On a 270 supervisor cluster, fully scheduled with topologies, Pacemaker resource
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Performance.html
+++ b/content/releases/2.1.0/Performance.html
@@ -363,7 +363,7 @@ The downside to this approach is that it adds the overhead of monitoring and man
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Project-ideas.html
+++ b/content/releases/2.1.0/Project-ideas.html
@@ -187,7 +187,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Rationale.html
+++ b/content/releases/2.1.0/Rationale.html
@@ -214,7 +214,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Resource_Aware_Scheduler_overview.html
+++ b/content/releases/2.1.0/Resource_Aware_Scheduler_overview.html
@@ -729,7 +729,7 @@ The effective resource of a rack, which is also the subordinate resource, is com
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Running-topologies-on-a-production-cluster.html
+++ b/content/releases/2.1.0/Running-topologies-on-a-production-cluster.html
@@ -250,7 +250,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/SECURITY.html
+++ b/content/releases/2.1.0/SECURITY.html
@@ -809,7 +809,7 @@ on all possible worker hosts.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/STORM-UI-REST-API.html
+++ b/content/releases/2.1.0/STORM-UI-REST-API.html
@@ -3150,7 +3150,7 @@ to use the POST option instead.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Serialization-(prior-to-0.6.0).html
+++ b/content/releases/2.1.0/Serialization-(prior-to-0.6.0).html
@@ -226,7 +226,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Serialization.html
+++ b/content/releases/2.1.0/Serialization.html
@@ -244,7 +244,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Serializers.html
+++ b/content/releases/2.1.0/Serializers.html
@@ -185,7 +185,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Setting-up-a-Storm-cluster.html
+++ b/content/releases/2.1.0/Setting-up-a-Storm-cluster.html
@@ -298,7 +298,7 @@ The time to allow any given healthcheck script to run before it is marked failed
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Setting-up-development-environment.html
+++ b/content/releases/2.1.0/Setting-up-development-environment.html
@@ -209,7 +209,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Spout-implementations.html
+++ b/content/releases/2.1.0/Spout-implementations.html
@@ -189,7 +189,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/State-checkpointing.html
+++ b/content/releases/2.1.0/State-checkpointing.html
@@ -459,7 +459,7 @@ Even if worker crashes at commit phase, after restart it will read pending-commi
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Storm-Scheduler.html
+++ b/content/releases/2.1.0/Storm-Scheduler.html
@@ -201,7 +201,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Storm-multi-language-protocol-(versions-0.7.0-and-below).html
+++ b/content/releases/2.1.0/Storm-multi-language-protocol-(versions-0.7.0-and-below).html
@@ -291,7 +291,7 @@ file lets the supervisor know the PID so it can shutdown the process later on.</
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Stream-API.html
+++ b/content/releases/2.1.0/Stream-API.html
@@ -603,7 +603,7 @@ via <code>build()</code> and submit it like a normal storm topology via <code>St
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Structure-of-the-codebase.html
+++ b/content/releases/2.1.0/Structure-of-the-codebase.html
@@ -313,7 +313,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Support-for-non-java-languages.html
+++ b/content/releases/2.1.0/Support-for-non-java-languages.html
@@ -188,7 +188,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Transactional-topologies.html
+++ b/content/releases/2.1.0/Transactional-topologies.html
@@ -548,7 +548,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Trident-API-Overview.html
+++ b/content/releases/2.1.0/Trident-API-Overview.html
@@ -707,7 +707,7 @@ Partition 2:
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Trident-RAS-API.html
+++ b/content/releases/2.1.0/Trident-RAS-API.html
@@ -230,7 +230,7 @@ Resources are declared per operation, but get combined within boundaries.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Trident-spouts.html
+++ b/content/releases/2.1.0/Trident-spouts.html
@@ -220,7 +220,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Trident-state.html
+++ b/content/releases/2.1.0/Trident-state.html
@@ -453,7 +453,7 @@ apple =&gt; [count=10, txid=2]
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Trident-tutorial.html
+++ b/content/releases/2.1.0/Trident-tutorial.html
@@ -396,7 +396,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Troubleshooting.html
+++ b/content/releases/2.1.0/Troubleshooting.html
@@ -317,7 +317,7 @@ Caused by: java.util.ConcurrentModificationException
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Tutorial.html
+++ b/content/releases/2.1.0/Tutorial.html
@@ -440,7 +440,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Understanding-the-parallelism-of-a-Storm-topology.html
+++ b/content/releases/2.1.0/Understanding-the-parallelism-of-a-Storm-topology.html
@@ -312,7 +312,7 @@ $ storm rebalance mytopology -n 5 -e blue-spout=3 -e yellow-bolt=10
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Using-non-JVM-languages-with-Storm.html
+++ b/content/releases/2.1.0/Using-non-JVM-languages-with-Storm.html
@@ -236,7 +236,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/Windowing.html
+++ b/content/releases/2.1.0/Windowing.html
@@ -517,7 +517,7 @@ which will help you get started.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/cgroups_in_storm.html
+++ b/content/releases/2.1.0/cgroups_in_storm.html
@@ -353,7 +353,7 @@ out.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/distcache-blobstore.html
+++ b/content/releases/2.1.0/distcache-blobstore.html
@@ -837,7 +837,7 @@ struct BeginDownloadResult {
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/dynamic-log-level-settings.html
+++ b/content/releases/2.1.0/dynamic-log-level-settings.html
@@ -217,7 +217,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/dynamic-worker-profiling.html
+++ b/content/releases/2.1.0/dynamic-worker-profiling.html
@@ -209,7 +209,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/flux.html
+++ b/content/releases/2.1.0/flux.html
@@ -951,7 +951,7 @@ same file. Includes may be either files, or classpath resources.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/index.html
+++ b/content/releases/2.1.0/index.html
@@ -326,7 +326,7 @@ But small change will not affect the user experience. We will notify the user wh
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/metrics_v2.html
+++ b/content/releases/2.1.0/metrics_v2.html
@@ -310,7 +310,7 @@ interface:</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/nimbus-ha-design.html
+++ b/content/releases/2.1.0/nimbus-ha-design.html
@@ -399,7 +399,7 @@ So you should expect your topology submission time to be somewhere between 0 to 
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/storm-cassandra.html
+++ b/content/releases/2.1.0/storm-cassandra.html
@@ -411,7 +411,7 @@ The stream is partitioned among the bolt&#39;s tasks based on the specified row 
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/storm-elasticsearch.html
+++ b/content/releases/2.1.0/storm-elasticsearch.html
@@ -283,7 +283,7 @@ You can refer implementation of DefaultEsTupleMapper to see how to implement you
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/storm-eventhubs.html
+++ b/content/releases/2.1.0/storm-eventhubs.html
@@ -216,7 +216,7 @@ If you want to send messages to all partitions, use &quot;-1&quot; as partitionI
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/storm-hbase.html
+++ b/content/releases/2.1.0/storm-hbase.html
@@ -433,7 +433,7 @@ Word: 'watermelon', Count: 6806
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/storm-hdfs.html
+++ b/content/releases/2.1.0/storm-hdfs.html
@@ -783,7 +783,7 @@ However, the later mechanism is deprecated as it does not allow multiple Hdfs sp
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/storm-hive.html
+++ b/content/releases/2.1.0/storm-hive.html
@@ -341,7 +341,7 @@ User should make sure that Tuple field names are matched to the table column nam
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/storm-jdbc.html
+++ b/content/releases/2.1.0/storm-jdbc.html
@@ -437,7 +437,7 @@ storm jar org.apache.storm.jdbc.topology.UserPersistenceTopology <dataSourceClas
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/storm-jms-example.html
+++ b/content/releases/2.1.0/storm-jms-example.html
@@ -286,7 +286,7 @@ DEBUG (backtype.storm.contrib.jms.spout.JmsSpout:251) - JMS Message acked: ID:bu
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/storm-jms-spring.html
+++ b/content/releases/2.1.0/storm-jms-spring.html
@@ -201,7 +201,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/storm-jms.html
+++ b/content/releases/2.1.0/storm-jms.html
@@ -207,7 +207,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/storm-kafka-client.html
+++ b/content/releases/2.1.0/storm-kafka-client.html
@@ -571,7 +571,7 @@ and Kafka 0.10.1.0 <a href="https://kafka.apache.org/0101/javadoc/index.html?org
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/storm-kinesis.html
+++ b/content/releases/2.1.0/storm-kinesis.html
@@ -321,7 +321,7 @@ However, storm can still call next tuple on the spout because there is only 1 pe
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/storm-metricstore.html
+++ b/content/releases/2.1.0/storm-metricstore.html
@@ -369,7 +369,7 @@ fields are as follows:</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/storm-mongodb.html
+++ b/content/releases/2.1.0/storm-mongodb.html
@@ -455,7 +455,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/storm-mqtt.html
+++ b/content/releases/2.1.0/storm-mqtt.html
@@ -521,7 +521,7 @@ keystore/truststore need to be available on all worker nodes where the spout/bol
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/storm-opentsdb.html
+++ b/content/releases/2.1.0/storm-opentsdb.html
@@ -226,7 +226,7 @@ configured HBase cluster to push/query the data.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/storm-pmml.html
+++ b/content/releases/2.1.0/storm-pmml.html
@@ -213,7 +213,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/storm-redis.html
+++ b/content/releases/2.1.0/storm-redis.html
@@ -420,7 +420,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/storm-rocketmq.html
+++ b/content/releases/2.1.0/storm-rocketmq.html
@@ -264,7 +264,7 @@ RocketMqBolt send messages async by default. You can change this by invoking <co
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/storm-solr.html
+++ b/content/releases/2.1.0/storm-solr.html
@@ -346,7 +346,7 @@ and then generate an uber jar with all the dependencies.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/storm-sql-example.html
+++ b/content/releases/2.1.0/storm-sql-example.html
@@ -412,7 +412,7 @@ This page assumes that GetTime2 is in classpath, for simplicity.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/storm-sql-internal.html
+++ b/content/releases/2.1.0/storm-sql-internal.html
@@ -233,7 +233,7 @@ You can use <code>--jars</code> or <code>--artifacts</code> option to <code>stor
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/storm-sql-reference.html
+++ b/content/releases/2.1.0/storm-sql-reference.html
@@ -2140,7 +2140,7 @@ You can put the <code>core-site.xml</code> and <code>hdfs-site.xml</code> into t
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/storm-sql.html
+++ b/content/releases/2.1.0/storm-sql.html
@@ -349,7 +349,7 @@ public class Generated_STREAMSCALCREL_33_0 implements org.apache.storm.sql.runti
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.1.0/windows-users-guide.html
+++ b/content/releases/2.1.0/windows-users-guide.html
@@ -210,7 +210,7 @@ created as a convienence, so it is not a 100% backwards compatible change.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Acking-framework-implementation.html
+++ b/content/releases/2.2.0/Acking-framework-implementation.html
@@ -218,7 +218,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Classpath-handling.html
+++ b/content/releases/2.2.0/Classpath-handling.html
@@ -211,7 +211,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Clojure-DSL.html
+++ b/content/releases/2.2.0/Clojure-DSL.html
@@ -409,7 +409,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/ClusterMetrics.html
+++ b/content/releases/2.2.0/ClusterMetrics.html
@@ -1257,7 +1257,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Command-line-client.html
+++ b/content/releases/2.2.0/Command-line-client.html
@@ -536,7 +536,7 @@ and timeout is integer seconds.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Common-patterns.html
+++ b/content/releases/2.2.0/Common-patterns.html
@@ -250,7 +250,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Concepts.html
+++ b/content/releases/2.2.0/Concepts.html
@@ -310,7 +310,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Configuration.html
+++ b/content/releases/2.2.0/Configuration.html
@@ -225,7 +225,7 @@ the name of your Config class.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Contributing-to-Storm.html
+++ b/content/releases/2.2.0/Contributing-to-Storm.html
@@ -210,7 +210,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Creating-a-new-Storm-project.html
+++ b/content/releases/2.2.0/Creating-a-new-Storm-project.html
@@ -204,7 +204,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/DSLs-and-multilang-adapters.html
+++ b/content/releases/2.2.0/DSLs-and-multilang-adapters.html
@@ -190,7 +190,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Daemon-Fault-Tolerance.html
+++ b/content/releases/2.2.0/Daemon-Fault-Tolerance.html
@@ -207,7 +207,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Defining-a-non-jvm-language-dsl-for-storm.html
+++ b/content/releases/2.2.0/Defining-a-non-jvm-language-dsl-for-storm.html
@@ -203,7 +203,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Distributed-RPC.html
+++ b/content/releases/2.2.0/Distributed-RPC.html
@@ -385,7 +385,7 @@ try (DRPCClient drpc = DRPCClient.getConfiguredClient(conf)) {
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Eventlogging.html
+++ b/content/releases/2.2.0/Eventlogging.html
@@ -307,7 +307,7 @@ One of idea to avoid this is making your implementation of IEventLogger as <code
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/FAQ.html
+++ b/content/releases/2.2.0/FAQ.html
@@ -314,7 +314,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Fault-tolerance.html
+++ b/content/releases/2.2.0/Fault-tolerance.html
@@ -207,7 +207,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Generic-resources.html
+++ b/content/releases/2.2.0/Generic-resources.html
@@ -216,7 +216,7 @@ Example of Usage:
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Guaranteeing-message-processing.html
+++ b/content/releases/2.2.0/Guaranteeing-message-processing.html
@@ -339,7 +339,7 @@ This page describes how Storm can guarantee at least once processing.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Hooks.html
+++ b/content/releases/2.2.0/Hooks.html
@@ -194,7 +194,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/IConfigLoader.html
+++ b/content/releases/2.2.0/IConfigLoader.html
@@ -233,7 +233,7 @@ For <code>FileConfigLoader</code>, this is the URI pointing to a file.</li>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Implementation-docs.html
+++ b/content/releases/2.2.0/Implementation-docs.html
@@ -193,7 +193,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Installing-native-dependencies.html
+++ b/content/releases/2.2.0/Installing-native-dependencies.html
@@ -213,7 +213,7 @@ sudo make install
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Joins.html
+++ b/content/releases/2.2.0/Joins.html
@@ -310,7 +310,7 @@ can occur when its value is set to null.</li>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Kestrel-and-Storm.html
+++ b/content/releases/2.2.0/Kestrel-and-Storm.html
@@ -371,7 +371,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Lifecycle-of-a-topology.html
+++ b/content/releases/2.2.0/Lifecycle-of-a-topology.html
@@ -299,7 +299,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Local-mode.html
+++ b/content/releases/2.2.0/Local-mode.html
@@ -253,7 +253,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Logs.html
+++ b/content/releases/2.2.0/Logs.html
@@ -209,7 +209,7 @@ Log Search supports searching in a certain log file or in all of a topology&#39;
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Maven.html
+++ b/content/releases/2.2.0/Maven.html
@@ -195,7 +195,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Message-passing-implementation.html
+++ b/content/releases/2.2.0/Message-passing-implementation.html
@@ -224,7 +224,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Metrics.html
+++ b/content/releases/2.2.0/Metrics.html
@@ -510,7 +510,7 @@ Prior to STORM-2621 (v1.1.1, v1.2.0, and v2.0.0) these were the rate of entries,
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Multilang-protocol.html
+++ b/content/releases/2.2.0/Multilang-protocol.html
@@ -490,7 +490,7 @@ ShellBolt.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/NUMA.html
+++ b/content/releases/2.2.0/NUMA.html
@@ -274,7 +274,7 @@ implementations                                                                 
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Pacemaker.html
+++ b/content/releases/2.2.0/Pacemaker.html
@@ -291,7 +291,7 @@ On a 270 supervisor cluster, fully scheduled with topologies, Pacemaker resource
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Performance.html
+++ b/content/releases/2.2.0/Performance.html
@@ -363,7 +363,7 @@ The downside to this approach is that it adds the overhead of monitoring and man
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Project-ideas.html
+++ b/content/releases/2.2.0/Project-ideas.html
@@ -187,7 +187,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Rationale.html
+++ b/content/releases/2.2.0/Rationale.html
@@ -214,7 +214,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Resource_Aware_Scheduler_overview.html
+++ b/content/releases/2.2.0/Resource_Aware_Scheduler_overview.html
@@ -729,7 +729,7 @@ The effective resource of a rack, which is also the subordinate resource, is com
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Running-topologies-on-a-production-cluster.html
+++ b/content/releases/2.2.0/Running-topologies-on-a-production-cluster.html
@@ -250,7 +250,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/SECURITY.html
+++ b/content/releases/2.2.0/SECURITY.html
@@ -815,7 +815,7 @@ on all possible worker hosts.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/STORM-UI-REST-API.html
+++ b/content/releases/2.2.0/STORM-UI-REST-API.html
@@ -3150,7 +3150,7 @@ to use the POST option instead.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Serialization-(prior-to-0.6.0).html
+++ b/content/releases/2.2.0/Serialization-(prior-to-0.6.0).html
@@ -226,7 +226,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Serialization.html
+++ b/content/releases/2.2.0/Serialization.html
@@ -244,7 +244,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Serializers.html
+++ b/content/releases/2.2.0/Serializers.html
@@ -185,7 +185,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Setting-up-a-Storm-cluster.html
+++ b/content/releases/2.2.0/Setting-up-a-Storm-cluster.html
@@ -298,7 +298,7 @@ The time to allow any given healthcheck script to run before it is marked failed
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Setting-up-development-environment.html
+++ b/content/releases/2.2.0/Setting-up-development-environment.html
@@ -209,7 +209,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Spout-implementations.html
+++ b/content/releases/2.2.0/Spout-implementations.html
@@ -189,7 +189,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/State-checkpointing.html
+++ b/content/releases/2.2.0/State-checkpointing.html
@@ -459,7 +459,7 @@ Even if worker crashes at commit phase, after restart it will read pending-commi
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Storm-Scheduler.html
+++ b/content/releases/2.2.0/Storm-Scheduler.html
@@ -201,7 +201,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Storm-multi-language-protocol-(versions-0.7.0-and-below).html
+++ b/content/releases/2.2.0/Storm-multi-language-protocol-(versions-0.7.0-and-below).html
@@ -291,7 +291,7 @@ file lets the supervisor know the PID so it can shutdown the process later on.</
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Stream-API.html
+++ b/content/releases/2.2.0/Stream-API.html
@@ -603,7 +603,7 @@ via <code>build()</code> and submit it like a normal storm topology via <code>St
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Structure-of-the-codebase.html
+++ b/content/releases/2.2.0/Structure-of-the-codebase.html
@@ -313,7 +313,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Support-for-non-java-languages.html
+++ b/content/releases/2.2.0/Support-for-non-java-languages.html
@@ -188,7 +188,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Transactional-topologies.html
+++ b/content/releases/2.2.0/Transactional-topologies.html
@@ -548,7 +548,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Trident-API-Overview.html
+++ b/content/releases/2.2.0/Trident-API-Overview.html
@@ -707,7 +707,7 @@ Partition 2:
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Trident-RAS-API.html
+++ b/content/releases/2.2.0/Trident-RAS-API.html
@@ -230,7 +230,7 @@ Resources are declared per operation, but get combined within boundaries.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Trident-spouts.html
+++ b/content/releases/2.2.0/Trident-spouts.html
@@ -220,7 +220,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Trident-state.html
+++ b/content/releases/2.2.0/Trident-state.html
@@ -453,7 +453,7 @@ apple =&gt; [count=10, txid=2]
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Trident-tutorial.html
+++ b/content/releases/2.2.0/Trident-tutorial.html
@@ -396,7 +396,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Troubleshooting.html
+++ b/content/releases/2.2.0/Troubleshooting.html
@@ -317,7 +317,7 @@ Caused by: java.util.ConcurrentModificationException
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Tutorial.html
+++ b/content/releases/2.2.0/Tutorial.html
@@ -440,7 +440,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Understanding-the-parallelism-of-a-Storm-topology.html
+++ b/content/releases/2.2.0/Understanding-the-parallelism-of-a-Storm-topology.html
@@ -312,7 +312,7 @@ $ storm rebalance mytopology -n 5 -e blue-spout=3 -e yellow-bolt=10
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Using-non-JVM-languages-with-Storm.html
+++ b/content/releases/2.2.0/Using-non-JVM-languages-with-Storm.html
@@ -236,7 +236,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/Windowing.html
+++ b/content/releases/2.2.0/Windowing.html
@@ -517,7 +517,7 @@ which will help you get started.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/cgroups_in_storm.html
+++ b/content/releases/2.2.0/cgroups_in_storm.html
@@ -353,7 +353,7 @@ out.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/distcache-blobstore.html
+++ b/content/releases/2.2.0/distcache-blobstore.html
@@ -849,7 +849,7 @@ struct BeginDownloadResult {
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/dynamic-log-level-settings.html
+++ b/content/releases/2.2.0/dynamic-log-level-settings.html
@@ -217,7 +217,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/dynamic-worker-profiling.html
+++ b/content/releases/2.2.0/dynamic-worker-profiling.html
@@ -209,7 +209,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/flux.html
+++ b/content/releases/2.2.0/flux.html
@@ -951,7 +951,7 @@ same file. Includes may be either files, or classpath resources.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/index.html
+++ b/content/releases/2.2.0/index.html
@@ -327,7 +327,7 @@ But small change will not affect the user experience. We will notify the user wh
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/metrics_v2.html
+++ b/content/releases/2.2.0/metrics_v2.html
@@ -312,7 +312,7 @@ interface:</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/nimbus-ha-design.html
+++ b/content/releases/2.2.0/nimbus-ha-design.html
@@ -399,7 +399,7 @@ So you should expect your topology submission time to be somewhere between 0 to 
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/storm-cassandra.html
+++ b/content/releases/2.2.0/storm-cassandra.html
@@ -411,7 +411,7 @@ The stream is partitioned among the bolt&#39;s tasks based on the specified row 
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/storm-elasticsearch.html
+++ b/content/releases/2.2.0/storm-elasticsearch.html
@@ -283,7 +283,7 @@ You can refer implementation of DefaultEsTupleMapper to see how to implement you
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/storm-eventhubs.html
+++ b/content/releases/2.2.0/storm-eventhubs.html
@@ -216,7 +216,7 @@ If you want to send messages to all partitions, use &quot;-1&quot; as partitionI
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/storm-hbase.html
+++ b/content/releases/2.2.0/storm-hbase.html
@@ -433,7 +433,7 @@ Word: 'watermelon', Count: 6806
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/storm-hdfs.html
+++ b/content/releases/2.2.0/storm-hdfs.html
@@ -783,7 +783,7 @@ However, the later mechanism is deprecated as it does not allow multiple Hdfs sp
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/storm-hive.html
+++ b/content/releases/2.2.0/storm-hive.html
@@ -341,7 +341,7 @@ User should make sure that Tuple field names are matched to the table column nam
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/storm-jdbc.html
+++ b/content/releases/2.2.0/storm-jdbc.html
@@ -437,7 +437,7 @@ storm jar org.apache.storm.jdbc.topology.UserPersistenceTopology <dataSourceClas
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/storm-jms-example.html
+++ b/content/releases/2.2.0/storm-jms-example.html
@@ -286,7 +286,7 @@ DEBUG (backtype.storm.contrib.jms.spout.JmsSpout:251) - JMS Message acked: ID:bu
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/storm-jms-spring.html
+++ b/content/releases/2.2.0/storm-jms-spring.html
@@ -201,7 +201,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/storm-jms.html
+++ b/content/releases/2.2.0/storm-jms.html
@@ -207,7 +207,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/storm-kafka-client.html
+++ b/content/releases/2.2.0/storm-kafka-client.html
@@ -571,7 +571,7 @@ and Kafka 0.10.1.0 <a href="https://kafka.apache.org/0101/javadoc/index.html?org
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/storm-kinesis.html
+++ b/content/releases/2.2.0/storm-kinesis.html
@@ -321,7 +321,7 @@ However, storm can still call next tuple on the spout because there is only 1 pe
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/storm-metricstore.html
+++ b/content/releases/2.2.0/storm-metricstore.html
@@ -369,7 +369,7 @@ fields are as follows:</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/storm-mongodb.html
+++ b/content/releases/2.2.0/storm-mongodb.html
@@ -455,7 +455,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/storm-mqtt.html
+++ b/content/releases/2.2.0/storm-mqtt.html
@@ -521,7 +521,7 @@ keystore/truststore need to be available on all worker nodes where the spout/bol
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/storm-opentsdb.html
+++ b/content/releases/2.2.0/storm-opentsdb.html
@@ -226,7 +226,7 @@ configured HBase cluster to push/query the data.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/storm-pmml.html
+++ b/content/releases/2.2.0/storm-pmml.html
@@ -213,7 +213,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/storm-redis.html
+++ b/content/releases/2.2.0/storm-redis.html
@@ -420,7 +420,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/storm-rocketmq.html
+++ b/content/releases/2.2.0/storm-rocketmq.html
@@ -264,7 +264,7 @@ RocketMqBolt send messages async by default. You can change this by invoking <co
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/storm-solr.html
+++ b/content/releases/2.2.0/storm-solr.html
@@ -346,7 +346,7 @@ and then generate an uber jar with all the dependencies.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/storm-sql-example.html
+++ b/content/releases/2.2.0/storm-sql-example.html
@@ -412,7 +412,7 @@ This page assumes that GetTime2 is in classpath, for simplicity.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/storm-sql-internal.html
+++ b/content/releases/2.2.0/storm-sql-internal.html
@@ -233,7 +233,7 @@ You can use <code>--jars</code> or <code>--artifacts</code> option to <code>stor
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/storm-sql-reference.html
+++ b/content/releases/2.2.0/storm-sql-reference.html
@@ -2140,7 +2140,7 @@ You can put the <code>core-site.xml</code> and <code>hdfs-site.xml</code> into t
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/storm-sql.html
+++ b/content/releases/2.2.0/storm-sql.html
@@ -349,7 +349,7 @@ public class Generated_STREAMSCALCREL_33_0 implements org.apache.storm.sql.runti
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.2.0/windows-users-guide.html
+++ b/content/releases/2.2.0/windows-users-guide.html
@@ -210,7 +210,7 @@ created as a convienence, so it is not a 100% backwards compatible change.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Acking-framework-implementation.html
+++ b/content/releases/2.3.0/Acking-framework-implementation.html
@@ -218,7 +218,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Classpath-handling.html
+++ b/content/releases/2.3.0/Classpath-handling.html
@@ -211,7 +211,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Clojure-DSL.html
+++ b/content/releases/2.3.0/Clojure-DSL.html
@@ -409,7 +409,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/ClusterMetrics.html
+++ b/content/releases/2.3.0/ClusterMetrics.html
@@ -1289,7 +1289,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Command-line-client.html
+++ b/content/releases/2.3.0/Command-line-client.html
@@ -536,7 +536,7 @@ and timeout is integer seconds.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Common-patterns.html
+++ b/content/releases/2.3.0/Common-patterns.html
@@ -250,7 +250,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Concepts.html
+++ b/content/releases/2.3.0/Concepts.html
@@ -310,7 +310,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Configuration.html
+++ b/content/releases/2.3.0/Configuration.html
@@ -225,7 +225,7 @@ the name of your Config class.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Contributing-to-Storm.html
+++ b/content/releases/2.3.0/Contributing-to-Storm.html
@@ -210,7 +210,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Creating-a-new-Storm-project.html
+++ b/content/releases/2.3.0/Creating-a-new-Storm-project.html
@@ -204,7 +204,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/DSLs-and-multilang-adapters.html
+++ b/content/releases/2.3.0/DSLs-and-multilang-adapters.html
@@ -190,7 +190,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Daemon-Fault-Tolerance.html
+++ b/content/releases/2.3.0/Daemon-Fault-Tolerance.html
@@ -207,7 +207,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Defining-a-non-jvm-language-dsl-for-storm.html
+++ b/content/releases/2.3.0/Defining-a-non-jvm-language-dsl-for-storm.html
@@ -203,7 +203,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Distributed-RPC.html
+++ b/content/releases/2.3.0/Distributed-RPC.html
@@ -385,7 +385,7 @@ try (DRPCClient drpc = DRPCClient.getConfiguredClient(conf)) {
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Docker-support.html
+++ b/content/releases/2.3.0/Docker-support.html
@@ -346,7 +346,7 @@ is used. You can use <code>conf/seccomp.json.example</code> provided or you can 
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Eventlogging.html
+++ b/content/releases/2.3.0/Eventlogging.html
@@ -307,7 +307,7 @@ One of idea to avoid this is making your implementation of IEventLogger as <code
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/FAQ.html
+++ b/content/releases/2.3.0/FAQ.html
@@ -314,7 +314,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Fault-tolerance.html
+++ b/content/releases/2.3.0/Fault-tolerance.html
@@ -207,7 +207,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Generic-resources.html
+++ b/content/releases/2.3.0/Generic-resources.html
@@ -216,7 +216,7 @@ Example of Usage:
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Guaranteeing-message-processing.html
+++ b/content/releases/2.3.0/Guaranteeing-message-processing.html
@@ -339,7 +339,7 @@ This page describes how Storm can guarantee at least once processing.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Hooks.html
+++ b/content/releases/2.3.0/Hooks.html
@@ -194,7 +194,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/IConfigLoader.html
+++ b/content/releases/2.3.0/IConfigLoader.html
@@ -233,7 +233,7 @@ For <code>FileConfigLoader</code>, this is the URI pointing to a file.</li>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Implementation-docs.html
+++ b/content/releases/2.3.0/Implementation-docs.html
@@ -193,7 +193,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Installing-native-dependencies.html
+++ b/content/releases/2.3.0/Installing-native-dependencies.html
@@ -213,7 +213,7 @@ sudo make install
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Joins.html
+++ b/content/releases/2.3.0/Joins.html
@@ -310,7 +310,7 @@ can occur when its value is set to null.</li>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Kestrel-and-Storm.html
+++ b/content/releases/2.3.0/Kestrel-and-Storm.html
@@ -371,7 +371,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Lifecycle-of-a-topology.html
+++ b/content/releases/2.3.0/Lifecycle-of-a-topology.html
@@ -299,7 +299,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Local-mode.html
+++ b/content/releases/2.3.0/Local-mode.html
@@ -253,7 +253,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/LocalityAwareness.html
+++ b/content/releases/2.3.0/LocalityAwareness.html
@@ -275,7 +275,7 @@ with network proximity needs before being scheduled. This is a best-effort to sp
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Logs.html
+++ b/content/releases/2.3.0/Logs.html
@@ -209,7 +209,7 @@ Log Search supports searching in a certain log file or in all of a topology&#39;
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Maven.html
+++ b/content/releases/2.3.0/Maven.html
@@ -195,7 +195,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Message-passing-implementation.html
+++ b/content/releases/2.3.0/Message-passing-implementation.html
@@ -224,7 +224,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Metrics.html
+++ b/content/releases/2.3.0/Metrics.html
@@ -499,7 +499,7 @@ connected to a worker with the given host/port.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Multilang-protocol.html
+++ b/content/releases/2.3.0/Multilang-protocol.html
@@ -490,7 +490,7 @@ ShellBolt.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/NUMA.html
+++ b/content/releases/2.3.0/NUMA.html
@@ -274,7 +274,7 @@ implementations                                                                 
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/OCI-support.html
+++ b/content/releases/2.3.0/OCI-support.html
@@ -1936,7 +1936,7 @@ restrictions. You can use <code>conf/seccomp.json.example</code> provided or you
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Pacemaker.html
+++ b/content/releases/2.3.0/Pacemaker.html
@@ -291,7 +291,7 @@ On a 270 supervisor cluster, fully scheduled with topologies, Pacemaker resource
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Performance.html
+++ b/content/releases/2.3.0/Performance.html
@@ -363,7 +363,7 @@ The downside to this approach is that it adds the overhead of monitoring and man
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Project-ideas.html
+++ b/content/releases/2.3.0/Project-ideas.html
@@ -187,7 +187,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Rationale.html
+++ b/content/releases/2.3.0/Rationale.html
@@ -214,7 +214,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Resource_Aware_Scheduler_overview.html
+++ b/content/releases/2.3.0/Resource_Aware_Scheduler_overview.html
@@ -729,7 +729,7 @@ The effective resource of a rack, which is also the subordinate resource, is com
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Running-topologies-on-a-production-cluster.html
+++ b/content/releases/2.3.0/Running-topologies-on-a-production-cluster.html
@@ -250,7 +250,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/SECURITY.html
+++ b/content/releases/2.3.0/SECURITY.html
@@ -815,7 +815,7 @@ on all possible worker hosts.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/STORM-UI-REST-API.html
+++ b/content/releases/2.3.0/STORM-UI-REST-API.html
@@ -3192,7 +3192,7 @@ to use the POST option instead.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Serialization-(prior-to-0.6.0).html
+++ b/content/releases/2.3.0/Serialization-(prior-to-0.6.0).html
@@ -226,7 +226,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Serialization.html
+++ b/content/releases/2.3.0/Serialization.html
@@ -244,7 +244,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Serializers.html
+++ b/content/releases/2.3.0/Serializers.html
@@ -185,7 +185,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Setting-up-a-Storm-cluster.html
+++ b/content/releases/2.3.0/Setting-up-a-Storm-cluster.html
@@ -298,7 +298,7 @@ The time to allow any given healthcheck script to run before it is marked failed
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Setting-up-development-environment.html
+++ b/content/releases/2.3.0/Setting-up-development-environment.html
@@ -209,7 +209,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Spout-implementations.html
+++ b/content/releases/2.3.0/Spout-implementations.html
@@ -189,7 +189,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/State-checkpointing.html
+++ b/content/releases/2.3.0/State-checkpointing.html
@@ -459,7 +459,7 @@ Even if worker crashes at commit phase, after restart it will read pending-commi
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Storm-Scheduler.html
+++ b/content/releases/2.3.0/Storm-Scheduler.html
@@ -201,7 +201,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Storm-multi-language-protocol-(versions-0.7.0-and-below).html
+++ b/content/releases/2.3.0/Storm-multi-language-protocol-(versions-0.7.0-and-below).html
@@ -291,7 +291,7 @@ file lets the supervisor know the PID so it can shutdown the process later on.</
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Stream-API.html
+++ b/content/releases/2.3.0/Stream-API.html
@@ -603,7 +603,7 @@ via <code>build()</code> and submit it like a normal storm topology via <code>St
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Structure-of-the-codebase.html
+++ b/content/releases/2.3.0/Structure-of-the-codebase.html
@@ -313,7 +313,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Support-for-non-java-languages.html
+++ b/content/releases/2.3.0/Support-for-non-java-languages.html
@@ -188,7 +188,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Transactional-topologies.html
+++ b/content/releases/2.3.0/Transactional-topologies.html
@@ -548,7 +548,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Trident-API-Overview.html
+++ b/content/releases/2.3.0/Trident-API-Overview.html
@@ -707,7 +707,7 @@ Partition 2:
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Trident-RAS-API.html
+++ b/content/releases/2.3.0/Trident-RAS-API.html
@@ -230,7 +230,7 @@ Resources are declared per operation, but get combined within boundaries.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Trident-spouts.html
+++ b/content/releases/2.3.0/Trident-spouts.html
@@ -220,7 +220,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Trident-state.html
+++ b/content/releases/2.3.0/Trident-state.html
@@ -453,7 +453,7 @@ apple =&gt; [count=10, txid=2]
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Trident-tutorial.html
+++ b/content/releases/2.3.0/Trident-tutorial.html
@@ -396,7 +396,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Troubleshooting.html
+++ b/content/releases/2.3.0/Troubleshooting.html
@@ -317,7 +317,7 @@ Caused by: java.util.ConcurrentModificationException
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Tutorial.html
+++ b/content/releases/2.3.0/Tutorial.html
@@ -440,7 +440,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Understanding-the-parallelism-of-a-Storm-topology.html
+++ b/content/releases/2.3.0/Understanding-the-parallelism-of-a-Storm-topology.html
@@ -312,7 +312,7 @@ $ storm rebalance mytopology -n 5 -e blue-spout=3 -e yellow-bolt=10
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Using-non-JVM-languages-with-Storm.html
+++ b/content/releases/2.3.0/Using-non-JVM-languages-with-Storm.html
@@ -236,7 +236,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/Windowing.html
+++ b/content/releases/2.3.0/Windowing.html
@@ -517,7 +517,7 @@ which will help you get started.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/cgroups_in_storm.html
+++ b/content/releases/2.3.0/cgroups_in_storm.html
@@ -382,7 +382,7 @@ out.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/distcache-blobstore.html
+++ b/content/releases/2.3.0/distcache-blobstore.html
@@ -852,7 +852,7 @@ struct BeginDownloadResult {
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/dynamic-log-level-settings.html
+++ b/content/releases/2.3.0/dynamic-log-level-settings.html
@@ -217,7 +217,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/dynamic-worker-profiling.html
+++ b/content/releases/2.3.0/dynamic-worker-profiling.html
@@ -209,7 +209,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/flux.html
+++ b/content/releases/2.3.0/flux.html
@@ -951,7 +951,7 @@ same file. Includes may be either files, or classpath resources.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/index.html
+++ b/content/releases/2.3.0/index.html
@@ -327,7 +327,7 @@ But small change will not affect the user experience. We will notify the user wh
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/metrics_v2.html
+++ b/content/releases/2.3.0/metrics_v2.html
@@ -340,7 +340,7 @@ Default values will be used if they are not set or set to <code>null</code>.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/nimbus-ha-design.html
+++ b/content/releases/2.3.0/nimbus-ha-design.html
@@ -399,7 +399,7 @@ So you should expect your topology submission time to be somewhere between 0 to 
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/storm-cassandra.html
+++ b/content/releases/2.3.0/storm-cassandra.html
@@ -411,7 +411,7 @@ The stream is partitioned among the bolt&#39;s tasks based on the specified row 
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/storm-elasticsearch.html
+++ b/content/releases/2.3.0/storm-elasticsearch.html
@@ -283,7 +283,7 @@ You can refer implementation of DefaultEsTupleMapper to see how to implement you
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/storm-eventhubs.html
+++ b/content/releases/2.3.0/storm-eventhubs.html
@@ -216,7 +216,7 @@ If you want to send messages to all partitions, use &quot;-1&quot; as partitionI
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/storm-hbase.html
+++ b/content/releases/2.3.0/storm-hbase.html
@@ -433,7 +433,7 @@ Word: 'watermelon', Count: 6806
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/storm-hdfs.html
+++ b/content/releases/2.3.0/storm-hdfs.html
@@ -783,7 +783,7 @@ However, the later mechanism is deprecated as it does not allow multiple Hdfs sp
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/storm-hive.html
+++ b/content/releases/2.3.0/storm-hive.html
@@ -341,7 +341,7 @@ User should make sure that Tuple field names are matched to the table column nam
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/storm-jdbc.html
+++ b/content/releases/2.3.0/storm-jdbc.html
@@ -437,7 +437,7 @@ storm jar org.apache.storm.jdbc.topology.UserPersistenceTopology <dataSourceClas
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/storm-jms-example.html
+++ b/content/releases/2.3.0/storm-jms-example.html
@@ -286,7 +286,7 @@ DEBUG (backtype.storm.contrib.jms.spout.JmsSpout:251) - JMS Message acked: ID:bu
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/storm-jms-spring.html
+++ b/content/releases/2.3.0/storm-jms-spring.html
@@ -201,7 +201,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/storm-jms.html
+++ b/content/releases/2.3.0/storm-jms.html
@@ -207,7 +207,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/storm-kafka-client.html
+++ b/content/releases/2.3.0/storm-kafka-client.html
@@ -571,7 +571,7 @@ and Kafka 0.10.1.0 <a href="https://kafka.apache.org/0101/javadoc/index.html?org
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/storm-kinesis.html
+++ b/content/releases/2.3.0/storm-kinesis.html
@@ -321,7 +321,7 @@ However, storm can still call next tuple on the spout because there is only 1 pe
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/storm-metricstore.html
+++ b/content/releases/2.3.0/storm-metricstore.html
@@ -369,7 +369,7 @@ fields are as follows:</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/storm-mongodb.html
+++ b/content/releases/2.3.0/storm-mongodb.html
@@ -455,7 +455,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/storm-mqtt.html
+++ b/content/releases/2.3.0/storm-mqtt.html
@@ -521,7 +521,7 @@ keystore/truststore need to be available on all worker nodes where the spout/bol
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/storm-opentsdb.html
+++ b/content/releases/2.3.0/storm-opentsdb.html
@@ -226,7 +226,7 @@ configured HBase cluster to push/query the data.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/storm-pmml.html
+++ b/content/releases/2.3.0/storm-pmml.html
@@ -213,7 +213,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/storm-redis.html
+++ b/content/releases/2.3.0/storm-redis.html
@@ -420,7 +420,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/storm-rocketmq.html
+++ b/content/releases/2.3.0/storm-rocketmq.html
@@ -264,7 +264,7 @@ RocketMqBolt send messages async by default. You can change this by invoking <co
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/storm-solr.html
+++ b/content/releases/2.3.0/storm-solr.html
@@ -346,7 +346,7 @@ and then generate an uber jar with all the dependencies.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/storm-sql-example.html
+++ b/content/releases/2.3.0/storm-sql-example.html
@@ -412,7 +412,7 @@ This page assumes that GetTime2 is in classpath, for simplicity.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/storm-sql-internal.html
+++ b/content/releases/2.3.0/storm-sql-internal.html
@@ -233,7 +233,7 @@ You can use <code>--jars</code> or <code>--artifacts</code> option to <code>stor
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/storm-sql-reference.html
+++ b/content/releases/2.3.0/storm-sql-reference.html
@@ -2140,7 +2140,7 @@ You can put the <code>core-site.xml</code> and <code>hdfs-site.xml</code> into t
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/storm-sql.html
+++ b/content/releases/2.3.0/storm-sql.html
@@ -349,7 +349,7 @@ public class Generated_STREAMSCALCREL_33_0 implements org.apache.storm.sql.runti
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/2.3.0/windows-users-guide.html
+++ b/content/releases/2.3.0/windows-users-guide.html
@@ -210,7 +210,7 @@ created as a convienence, so it is not a 100% backwards compatible change.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Acking-framework-implementation.html
+++ b/content/releases/current/Acking-framework-implementation.html
@@ -218,7 +218,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Classpath-handling.html
+++ b/content/releases/current/Classpath-handling.html
@@ -211,7 +211,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Clojure-DSL.html
+++ b/content/releases/current/Clojure-DSL.html
@@ -409,7 +409,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/ClusterMetrics.html
+++ b/content/releases/current/ClusterMetrics.html
@@ -1289,7 +1289,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Command-line-client.html
+++ b/content/releases/current/Command-line-client.html
@@ -536,7 +536,7 @@ and timeout is integer seconds.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Common-patterns.html
+++ b/content/releases/current/Common-patterns.html
@@ -250,7 +250,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Concepts.html
+++ b/content/releases/current/Concepts.html
@@ -310,7 +310,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Configuration.html
+++ b/content/releases/current/Configuration.html
@@ -225,7 +225,7 @@ the name of your Config class.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Contributing-to-Storm.html
+++ b/content/releases/current/Contributing-to-Storm.html
@@ -210,7 +210,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Creating-a-new-Storm-project.html
+++ b/content/releases/current/Creating-a-new-Storm-project.html
@@ -204,7 +204,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/DSLs-and-multilang-adapters.html
+++ b/content/releases/current/DSLs-and-multilang-adapters.html
@@ -190,7 +190,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Daemon-Fault-Tolerance.html
+++ b/content/releases/current/Daemon-Fault-Tolerance.html
@@ -207,7 +207,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Defining-a-non-jvm-language-dsl-for-storm.html
+++ b/content/releases/current/Defining-a-non-jvm-language-dsl-for-storm.html
@@ -203,7 +203,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Distributed-RPC.html
+++ b/content/releases/current/Distributed-RPC.html
@@ -385,7 +385,7 @@ try (DRPCClient drpc = DRPCClient.getConfiguredClient(conf)) {
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Docker-support.html
+++ b/content/releases/current/Docker-support.html
@@ -346,7 +346,7 @@ is used. You can use <code>conf/seccomp.json.example</code> provided or you can 
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Eventlogging.html
+++ b/content/releases/current/Eventlogging.html
@@ -307,7 +307,7 @@ One of idea to avoid this is making your implementation of IEventLogger as <code
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/FAQ.html
+++ b/content/releases/current/FAQ.html
@@ -314,7 +314,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Fault-tolerance.html
+++ b/content/releases/current/Fault-tolerance.html
@@ -207,7 +207,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Generic-resources.html
+++ b/content/releases/current/Generic-resources.html
@@ -216,7 +216,7 @@ Example of Usage:
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Guaranteeing-message-processing.html
+++ b/content/releases/current/Guaranteeing-message-processing.html
@@ -339,7 +339,7 @@ This page describes how Storm can guarantee at least once processing.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Hooks.html
+++ b/content/releases/current/Hooks.html
@@ -194,7 +194,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/IConfigLoader.html
+++ b/content/releases/current/IConfigLoader.html
@@ -233,7 +233,7 @@ For <code>FileConfigLoader</code>, this is the URI pointing to a file.</li>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Implementation-docs.html
+++ b/content/releases/current/Implementation-docs.html
@@ -193,7 +193,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Installing-native-dependencies.html
+++ b/content/releases/current/Installing-native-dependencies.html
@@ -213,7 +213,7 @@ sudo make install
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Joins.html
+++ b/content/releases/current/Joins.html
@@ -310,7 +310,7 @@ can occur when its value is set to null.</li>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Kestrel-and-Storm.html
+++ b/content/releases/current/Kestrel-and-Storm.html
@@ -371,7 +371,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Lifecycle-of-a-topology.html
+++ b/content/releases/current/Lifecycle-of-a-topology.html
@@ -299,7 +299,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Local-mode.html
+++ b/content/releases/current/Local-mode.html
@@ -253,7 +253,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/LocalityAwareness.html
+++ b/content/releases/current/LocalityAwareness.html
@@ -275,7 +275,7 @@ with network proximity needs before being scheduled. This is a best-effort to sp
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Logs.html
+++ b/content/releases/current/Logs.html
@@ -209,7 +209,7 @@ Log Search supports searching in a certain log file or in all of a topology&#39;
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Maven.html
+++ b/content/releases/current/Maven.html
@@ -195,7 +195,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Message-passing-implementation.html
+++ b/content/releases/current/Message-passing-implementation.html
@@ -224,7 +224,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Metrics.html
+++ b/content/releases/current/Metrics.html
@@ -499,7 +499,7 @@ connected to a worker with the given host/port.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Multilang-protocol.html
+++ b/content/releases/current/Multilang-protocol.html
@@ -490,7 +490,7 @@ ShellBolt.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/NUMA.html
+++ b/content/releases/current/NUMA.html
@@ -274,7 +274,7 @@ implementations                                                                 
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/OCI-support.html
+++ b/content/releases/current/OCI-support.html
@@ -1936,7 +1936,7 @@ restrictions. You can use <code>conf/seccomp.json.example</code> provided or you
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Pacemaker.html
+++ b/content/releases/current/Pacemaker.html
@@ -291,7 +291,7 @@ On a 270 supervisor cluster, fully scheduled with topologies, Pacemaker resource
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Performance.html
+++ b/content/releases/current/Performance.html
@@ -363,7 +363,7 @@ The downside to this approach is that it adds the overhead of monitoring and man
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Project-ideas.html
+++ b/content/releases/current/Project-ideas.html
@@ -187,7 +187,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Rationale.html
+++ b/content/releases/current/Rationale.html
@@ -214,7 +214,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Resource_Aware_Scheduler_overview.html
+++ b/content/releases/current/Resource_Aware_Scheduler_overview.html
@@ -729,7 +729,7 @@ The effective resource of a rack, which is also the subordinate resource, is com
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Running-topologies-on-a-production-cluster.html
+++ b/content/releases/current/Running-topologies-on-a-production-cluster.html
@@ -250,7 +250,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/SECURITY.html
+++ b/content/releases/current/SECURITY.html
@@ -815,7 +815,7 @@ on all possible worker hosts.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/STORM-UI-REST-API.html
+++ b/content/releases/current/STORM-UI-REST-API.html
@@ -3192,7 +3192,7 @@ to use the POST option instead.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Serialization-(prior-to-0.6.0).html
+++ b/content/releases/current/Serialization-(prior-to-0.6.0).html
@@ -226,7 +226,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Serialization.html
+++ b/content/releases/current/Serialization.html
@@ -244,7 +244,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Serializers.html
+++ b/content/releases/current/Serializers.html
@@ -185,7 +185,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Setting-up-a-Storm-cluster.html
+++ b/content/releases/current/Setting-up-a-Storm-cluster.html
@@ -298,7 +298,7 @@ The time to allow any given healthcheck script to run before it is marked failed
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Setting-up-development-environment.html
+++ b/content/releases/current/Setting-up-development-environment.html
@@ -209,7 +209,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Spout-implementations.html
+++ b/content/releases/current/Spout-implementations.html
@@ -189,7 +189,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/State-checkpointing.html
+++ b/content/releases/current/State-checkpointing.html
@@ -459,7 +459,7 @@ Even if worker crashes at commit phase, after restart it will read pending-commi
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Storm-Scheduler.html
+++ b/content/releases/current/Storm-Scheduler.html
@@ -201,7 +201,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Storm-multi-language-protocol-(versions-0.7.0-and-below).html
+++ b/content/releases/current/Storm-multi-language-protocol-(versions-0.7.0-and-below).html
@@ -291,7 +291,7 @@ file lets the supervisor know the PID so it can shutdown the process later on.</
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Stream-API.html
+++ b/content/releases/current/Stream-API.html
@@ -603,7 +603,7 @@ via <code>build()</code> and submit it like a normal storm topology via <code>St
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Structure-of-the-codebase.html
+++ b/content/releases/current/Structure-of-the-codebase.html
@@ -313,7 +313,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Support-for-non-java-languages.html
+++ b/content/releases/current/Support-for-non-java-languages.html
@@ -188,7 +188,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Transactional-topologies.html
+++ b/content/releases/current/Transactional-topologies.html
@@ -548,7 +548,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Trident-API-Overview.html
+++ b/content/releases/current/Trident-API-Overview.html
@@ -707,7 +707,7 @@ Partition 2:
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Trident-RAS-API.html
+++ b/content/releases/current/Trident-RAS-API.html
@@ -230,7 +230,7 @@ Resources are declared per operation, but get combined within boundaries.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Trident-spouts.html
+++ b/content/releases/current/Trident-spouts.html
@@ -220,7 +220,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Trident-state.html
+++ b/content/releases/current/Trident-state.html
@@ -453,7 +453,7 @@ apple =&gt; [count=10, txid=2]
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Trident-tutorial.html
+++ b/content/releases/current/Trident-tutorial.html
@@ -396,7 +396,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Troubleshooting.html
+++ b/content/releases/current/Troubleshooting.html
@@ -317,7 +317,7 @@ Caused by: java.util.ConcurrentModificationException
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Tutorial.html
+++ b/content/releases/current/Tutorial.html
@@ -440,7 +440,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Understanding-the-parallelism-of-a-Storm-topology.html
+++ b/content/releases/current/Understanding-the-parallelism-of-a-Storm-topology.html
@@ -312,7 +312,7 @@ $ storm rebalance mytopology -n 5 -e blue-spout=3 -e yellow-bolt=10
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Using-non-JVM-languages-with-Storm.html
+++ b/content/releases/current/Using-non-JVM-languages-with-Storm.html
@@ -236,7 +236,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/Windowing.html
+++ b/content/releases/current/Windowing.html
@@ -517,7 +517,7 @@ which will help you get started.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/cgroups_in_storm.html
+++ b/content/releases/current/cgroups_in_storm.html
@@ -382,7 +382,7 @@ out.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/distcache-blobstore.html
+++ b/content/releases/current/distcache-blobstore.html
@@ -852,7 +852,7 @@ struct BeginDownloadResult {
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/dynamic-log-level-settings.html
+++ b/content/releases/current/dynamic-log-level-settings.html
@@ -217,7 +217,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/dynamic-worker-profiling.html
+++ b/content/releases/current/dynamic-worker-profiling.html
@@ -209,7 +209,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/flux.html
+++ b/content/releases/current/flux.html
@@ -951,7 +951,7 @@ same file. Includes may be either files, or classpath resources.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/index.html
+++ b/content/releases/current/index.html
@@ -327,7 +327,7 @@ But small change will not affect the user experience. We will notify the user wh
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/metrics_v2.html
+++ b/content/releases/current/metrics_v2.html
@@ -340,7 +340,7 @@ Default values will be used if they are not set or set to <code>null</code>.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/nimbus-ha-design.html
+++ b/content/releases/current/nimbus-ha-design.html
@@ -399,7 +399,7 @@ So you should expect your topology submission time to be somewhere between 0 to 
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/storm-cassandra.html
+++ b/content/releases/current/storm-cassandra.html
@@ -411,7 +411,7 @@ The stream is partitioned among the bolt&#39;s tasks based on the specified row 
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/storm-elasticsearch.html
+++ b/content/releases/current/storm-elasticsearch.html
@@ -283,7 +283,7 @@ You can refer implementation of DefaultEsTupleMapper to see how to implement you
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/storm-eventhubs.html
+++ b/content/releases/current/storm-eventhubs.html
@@ -216,7 +216,7 @@ If you want to send messages to all partitions, use &quot;-1&quot; as partitionI
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/storm-hbase.html
+++ b/content/releases/current/storm-hbase.html
@@ -433,7 +433,7 @@ Word: 'watermelon', Count: 6806
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/storm-hdfs.html
+++ b/content/releases/current/storm-hdfs.html
@@ -783,7 +783,7 @@ However, the later mechanism is deprecated as it does not allow multiple Hdfs sp
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/storm-hive.html
+++ b/content/releases/current/storm-hive.html
@@ -341,7 +341,7 @@ User should make sure that Tuple field names are matched to the table column nam
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/storm-jdbc.html
+++ b/content/releases/current/storm-jdbc.html
@@ -437,7 +437,7 @@ storm jar org.apache.storm.jdbc.topology.UserPersistenceTopology <dataSourceClas
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/storm-jms-example.html
+++ b/content/releases/current/storm-jms-example.html
@@ -286,7 +286,7 @@ DEBUG (backtype.storm.contrib.jms.spout.JmsSpout:251) - JMS Message acked: ID:bu
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/storm-jms-spring.html
+++ b/content/releases/current/storm-jms-spring.html
@@ -201,7 +201,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/storm-jms.html
+++ b/content/releases/current/storm-jms.html
@@ -207,7 +207,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/storm-kafka-client.html
+++ b/content/releases/current/storm-kafka-client.html
@@ -571,7 +571,7 @@ and Kafka 0.10.1.0 <a href="https://kafka.apache.org/0101/javadoc/index.html?org
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/storm-kinesis.html
+++ b/content/releases/current/storm-kinesis.html
@@ -321,7 +321,7 @@ However, storm can still call next tuple on the spout because there is only 1 pe
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/storm-metricstore.html
+++ b/content/releases/current/storm-metricstore.html
@@ -369,7 +369,7 @@ fields are as follows:</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/storm-mongodb.html
+++ b/content/releases/current/storm-mongodb.html
@@ -455,7 +455,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/storm-mqtt.html
+++ b/content/releases/current/storm-mqtt.html
@@ -521,7 +521,7 @@ keystore/truststore need to be available on all worker nodes where the spout/bol
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/storm-opentsdb.html
+++ b/content/releases/current/storm-opentsdb.html
@@ -226,7 +226,7 @@ configured HBase cluster to push/query the data.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/storm-pmml.html
+++ b/content/releases/current/storm-pmml.html
@@ -213,7 +213,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/storm-redis.html
+++ b/content/releases/current/storm-redis.html
@@ -420,7 +420,7 @@
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/storm-rocketmq.html
+++ b/content/releases/current/storm-rocketmq.html
@@ -264,7 +264,7 @@ RocketMqBolt send messages async by default. You can change this by invoking <co
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/storm-solr.html
+++ b/content/releases/current/storm-solr.html
@@ -346,7 +346,7 @@ and then generate an uber jar with all the dependencies.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/storm-sql-example.html
+++ b/content/releases/current/storm-sql-example.html
@@ -412,7 +412,7 @@ This page assumes that GetTime2 is in classpath, for simplicity.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/storm-sql-internal.html
+++ b/content/releases/current/storm-sql-internal.html
@@ -233,7 +233,7 @@ You can use <code>--jars</code> or <code>--artifacts</code> option to <code>stor
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/storm-sql-reference.html
+++ b/content/releases/current/storm-sql-reference.html
@@ -2140,7 +2140,7 @@ You can put the <code>core-site.xml</code> and <code>hdfs-site.xml</code> into t
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/storm-sql.html
+++ b/content/releases/current/storm-sql.html
@@ -349,7 +349,7 @@ public class Generated_STREAMSCALCREL_33_0 implements org.apache.storm.sql.runti
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/releases/current/windows-users-guide.html
+++ b/content/releases/current/windows-users-guide.html
@@ -210,7 +210,7 @@ created as a convienence, so it is not a 100% backwards compatible change.</p>
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>

--- a/content/talksAndVideos.html
+++ b/content/talksAndVideos.html
@@ -643,7 +643,7 @@ The effort to rearchitect Apache Storm's core engine was born from the observati
         <hr/>
         <div class="row">   
             <div class="col-md-12">
-                <p align="center">Copyright © 2019 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
+                <p align="center">Copyright © 2021 <a href="http://www.apache.org">Apache Software Foundation</a>. All Rights Reserved. 
                     <br>Apache Storm, Apache, the Apache feather logo, and the Apache Storm project logos are trademarks of The Apache Software Foundation. 
                     <br>All other marks mentioned may be trademarks or registered trademarks of their respective owners.</p>
             </div>


### PR DESCRIPTION
I am not sure which one of the following we should choose for the copyright info:

1) "Copyright © 2021"

2) "Copyright © 2013-2021"
     2013 is when storm entered apache incubator

3) "Copyright © 2014-2021"
    2014 is when storm became a top-level project

4) "Copyright © 2012-2021"
    2012 is (possibly) the oldest content on the website.
(https://storm.apache.org/2012/08/02/storm080-released.html). But it
was still "backtype storm" instead of "apache storm".


This PR changes 2019 to 2021 (for now)